### PR TITLE
Fix UNC path building and add path extension to resolve hostname 

### DIFF
--- a/System.IO.Abstractions.SMB.Tests.Integration/DriveInfoTests.cs
+++ b/System.IO.Abstractions.SMB.Tests.Integration/DriveInfoTests.cs
@@ -89,6 +89,5 @@ namespace System.IO.Abstractions.SMB.Tests.Integration
             Assert.NotNull(shares);
         }
 
-
     }
 }

--- a/System.IO.Abstractions.SMB.Tests.Integration/IntegrationTestSettings.cs
+++ b/System.IO.Abstractions.SMB.Tests.Integration/IntegrationTestSettings.cs
@@ -28,8 +28,7 @@ namespace System.IO.Abstractions.SMB.Tests.Integration
         {
             get
             {
-                var s = Path.DirectorySeparatorChar;
-                return $"{s}{s}{HostName}{s}{ShareName}";
+                return $@"\\{HostName}\{ShareName}";
             }
         }
 

--- a/System.IO.Abstractions.SMB.Tests/Path/PathExtensionsTests.cs
+++ b/System.IO.Abstractions.SMB.Tests/Path/PathExtensionsTests.cs
@@ -46,7 +46,7 @@ namespace System.IO.Abstractions.SMB.Tests.Path
 
                 var builtSharePath = path.BuildSharePath(testBuildShareName);
 
-                string expectedPath = $"smb://{path.HostName()}/{testBuildShareName}";
+                string expectedPath = $"smb://{path.Hostname()}/{testBuildShareName}";
 
                 Assert.Equal(expectedPath, builtSharePath);
             }
@@ -62,7 +62,7 @@ namespace System.IO.Abstractions.SMB.Tests.Path
 
                 var builtSharePath = path.BuildSharePath(testBuildShareName);
 
-                string expectedPath = $@"\\{path.HostName()}\{testBuildShareName}";
+                string expectedPath = $@"\\{path.Hostname()}\{testBuildShareName}";
                 
                 Assert.Equal(expectedPath, builtSharePath);
             }
@@ -74,7 +74,7 @@ namespace System.IO.Abstractions.SMB.Tests.Path
             foreach (var property in _smbUriTestData.GetType().GetProperties())
             {
                 var path = (string)property.GetValue(_smbUriTestData);
-                var hostName = path.HostName();
+                var hostName = path.Hostname();
 
                 Assert.Equal("host", hostName);
             }
@@ -86,11 +86,12 @@ namespace System.IO.Abstractions.SMB.Tests.Path
             foreach (var property in _uncPathTestData.GetType().GetProperties())
             {
                 var path = (string)property.GetValue(_uncPathTestData);
-                var hostName = path.HostName();
+                var hostName = path.Hostname();
 
                 Assert.Equal("host", hostName);
             }
         }
+
 
         [Fact]
         public void SharePath_ReturnsSharePath_ForSmbUri()

--- a/System.IO.Abstractions.SMB.Tests/Path/PathExtensionsTests.cs
+++ b/System.IO.Abstractions.SMB.Tests/Path/PathExtensionsTests.cs
@@ -7,7 +7,6 @@ namespace System.IO.Abstractions.SMB.Tests.Path
     {
         private readonly IPathTestData _smbUriTestData;
         private readonly IPathTestData _uncPathTestData;
-        private readonly char s = IO.Path.DirectorySeparatorChar;
 
         public PathExtensionsTests()
         {
@@ -63,7 +62,7 @@ namespace System.IO.Abstractions.SMB.Tests.Path
 
                 var builtSharePath = path.BuildSharePath(testBuildShareName);
 
-                string expectedPath = $"{s}{s}{path.HostName()}{s}{testBuildShareName}";
+                string expectedPath = $@"\\{path.HostName()}\{testBuildShareName}";
                 
                 Assert.Equal(expectedPath, builtSharePath);
             }

--- a/System.IO.Abstractions.SMB.Tests/Path/PathTestData.cs
+++ b/System.IO.Abstractions.SMB.Tests/Path/PathTestData.cs
@@ -25,12 +25,10 @@ namespace System.IO.Abstractions.SMB.Tests.Path
 
     public class UncPathTestData : IPathTestData
     {
-        private char s = System.IO.Path.DirectorySeparatorChar;
-
-        public string Root { get { return $@"{s}{s}host{s}share"; } }
-        public string DirectoryAtRoot { get { return $@"{s}{s}host{s}share{s}dir"; } }
-        public string FileAtRoot { get { return $@"{s}{s}host{s}share{s}file.txt"; } }
-        public string NestedDirectoryAtRoot { get { return $@"{s}{s}host{s}share{s}dir{s}nested_dir"; } }
-        public string FileInNestedDirectoryAtRoot { get { return $@"{s}{s}host{s}share{s}dir{s}nested_dir{s}file.text"; } }
+        public string Root { get { return $@"\\host\share"; } }
+        public string DirectoryAtRoot { get { return $@"\\host\share\dir"; } }
+        public string FileAtRoot { get { return $@"\\host\share\file.txt"; } }
+        public string NestedDirectoryAtRoot { get { return $@"\\host\share\dir\nested_dir"; } }
+        public string FileInNestedDirectoryAtRoot { get { return $@"\\host\share\dir\nested_dir\file.text"; } }
     }
 }

--- a/System.IO.Abstractions.SMB2/Directory/SMBDirectory.cs
+++ b/System.IO.Abstractions.SMB2/Directory/SMBDirectory.cs
@@ -38,8 +38,7 @@ namespace System.IO.Abstractions.SMB
                 return base.CreateDirectory(path);
             }
 
-            var hostEntry = Dns.GetHostEntry(path.HostName());
-            var ipAddress = hostEntry.AddressList.First(a => a.AddressFamily == Net.Sockets.AddressFamily.InterNetwork);
+            IPAddress ipAddress = path.TryResolveHostnameFromPath();
 
             NTStatus status = NTStatus.STATUS_SUCCESS;
 
@@ -89,8 +88,7 @@ namespace System.IO.Abstractions.SMB
                 base.Delete(path);
             }
 
-            var hostEntry = Dns.GetHostEntry(path.HostName());
-            var ipAddress = hostEntry.AddressList.First(a => a.AddressFamily == Net.Sockets.AddressFamily.InterNetwork);
+            IPAddress ipAddress = path.TryResolveHostnameFromPath();
 
             NTStatus status = NTStatus.STATUS_SUCCESS;
 
@@ -140,8 +138,7 @@ namespace System.IO.Abstractions.SMB
 
             if (recursive)
             {
-                var hostEntry = Dns.GetHostEntry(path.HostName());
-                var ipAddress = hostEntry.AddressList.First(a => a.AddressFamily == Net.Sockets.AddressFamily.InterNetwork);
+                IPAddress ipAddress = path.TryResolveHostnameFromPath();
 
                 NTStatus status = NTStatus.STATUS_SUCCESS;
 
@@ -238,8 +235,7 @@ namespace System.IO.Abstractions.SMB
                 return base.EnumerateDirectories(path, searchPattern, searchOption);
             }
 
-            var hostEntry = Dns.GetHostEntry(path.HostName());
-            var ipAddress = hostEntry.AddressList.First(a => a.AddressFamily == Net.Sockets.AddressFamily.InterNetwork);
+            IPAddress ipAddress = path.TryResolveHostnameFromPath();
 
             NTStatus status = NTStatus.STATUS_SUCCESS;
 
@@ -326,8 +322,7 @@ namespace System.IO.Abstractions.SMB
                 return base.EnumerateFiles(path, searchPattern, searchOption);
             }
 
-            var hostEntry = Dns.GetHostEntry(path.HostName());
-            var ipAddress = hostEntry.AddressList.First(a => a.AddressFamily == Net.Sockets.AddressFamily.InterNetwork);
+            IPAddress ipAddress = path.TryResolveHostnameFromPath();
 
             NTStatus status = NTStatus.STATUS_SUCCESS;
 
@@ -419,8 +414,7 @@ namespace System.IO.Abstractions.SMB
                 return base.EnumerateFileSystemEntries(path, searchPattern, searchOption);
             }
 
-            var hostEntry = Dns.GetHostEntry(path.HostName());
-            var ipAddress = hostEntry.AddressList.First(a => a.AddressFamily == Net.Sockets.AddressFamily.InterNetwork);
+            IPAddress ipAddress = path.TryResolveHostnameFromPath();
 
             NTStatus status = NTStatus.STATUS_SUCCESS;
 
@@ -483,8 +477,7 @@ namespace System.IO.Abstractions.SMB
                 return base.Exists(path);
             }
 
-            var hostEntry = Dns.GetHostEntry(path.HostName());
-            var ipAddress = hostEntry.AddressList.First(a => a.AddressFamily == Net.Sockets.AddressFamily.InterNetwork);
+            IPAddress ipAddress = path.TryResolveHostnameFromPath();
 
             NTStatus status = NTStatus.STATUS_SUCCESS;
 

--- a/System.IO.Abstractions.SMB2/Directory/SMBDirectory.cs
+++ b/System.IO.Abstractions.SMB2/Directory/SMBDirectory.cs
@@ -38,7 +38,7 @@ namespace System.IO.Abstractions.SMB
                 return base.CreateDirectory(path);
             }
 
-            if(!path.TryResolveHostnameFromPath(out var ipAddress))
+            if (!path.TryResolveHostnameFromPath(out var ipAddress))
             {
                 throw new ArgumentException($"Unable to resolve \"{path.Hostname()}\"");
             }
@@ -66,14 +66,14 @@ namespace System.IO.Abstractions.SMB
             var relativePath = path.RelativeSharePath();
 
             ISMBFileStore fileStore = connection.SMBClient.TreeConnect(shareName, out status);
-            
+
             status.HandleStatus();
 
             status = fileStore.CreateFile(out object handle, out FileStatus fileStatus, relativePath, accessMask, 0, shareAccess,
                 disposition, createOptions, null);
 
             status.HandleStatus();
-           
+
             fileStore.CloseFile(handle);
 
             return _directoryInfoFactory.FromDirectoryName(path, credential);
@@ -98,12 +98,12 @@ namespace System.IO.Abstractions.SMB
 
             NTStatus status = NTStatus.STATUS_SUCCESS;
 
-            if(credential == null)
+            if (credential == null)
             {
                 credential = _credentialProvider.GetSMBCredential(path);
             }
 
-            if(EnumerateFileSystemEntries(path).Count() > 0)
+            if (EnumerateFileSystemEntries(path).Count() > 0)
             {
                 throw new IOException("Cannot delete directory. Directory is not empty.");
             }
@@ -114,10 +114,10 @@ namespace System.IO.Abstractions.SMB
                 var relativePath = path.RelativeSharePath();
 
                 ISMBFileStore fileStore = connection.SMBClient.TreeConnect(shareName, out status);
-                
+
                 status.HandleStatus();
 
-             
+
                 status = fileStore.CreateFile(out object handle, out FileStatus fileStatus, relativePath, AccessMask.DELETE, 0, ShareAccess.Delete,
                     CreateDisposition.FILE_OPEN, CreateOptions.FILE_DELETE_ON_CLOSE, null);
 
@@ -162,9 +162,9 @@ namespace System.IO.Abstractions.SMB
                     var relativePath = path.RelativeSharePath();
 
                     ISMBFileStore fileStore = connection.SMBClient.TreeConnect(shareName, out status);
-                    
+
                     status.HandleStatus();
-                    
+
                     int attempts = 0;
                     int allowedRetrys = 3;
                     object handle;
@@ -179,7 +179,7 @@ namespace System.IO.Abstractions.SMB
                     while (status == NTStatus.STATUS_PENDING && attempts < allowedRetrys);
 
                     status.HandleStatus();
-           
+
                     fileStore.QueryDirectory(out List<QueryDirectoryFileInformation> queryDirectoryFileInformation, handle, "*", FileInformationClass.FileDirectoryInformation);
 
                     foreach (var file in queryDirectoryFileInformation)
@@ -269,7 +269,7 @@ namespace System.IO.Abstractions.SMB
                     CreateDisposition.FILE_OPEN, CreateOptions.FILE_DIRECTORY_FILE, null);
 
                 status.HandleStatus();
-                
+
                 fileStore.QueryDirectory(out List<QueryDirectoryFileInformation> queryDirectoryFileInformation, handle, searchPattern, FileInformationClass.FileDirectoryInformation);
 
 
@@ -359,7 +359,7 @@ namespace System.IO.Abstractions.SMB
                     CreateDisposition.FILE_OPEN, CreateOptions.FILE_DIRECTORY_FILE, null);
 
                 status.HandleStatus();
-            
+
                 fileStore.QueryDirectory(out List<QueryDirectoryFileInformation> queryDirectoryFileInformation, handle, searchPattern, FileInformationClass.FileDirectoryInformation);
 
 
@@ -454,7 +454,7 @@ namespace System.IO.Abstractions.SMB
                     CreateDisposition.FILE_OPEN, CreateOptions.FILE_DIRECTORY_FILE, null);
 
                 status.HandleStatus();
-             
+
                 fileStore.QueryDirectory(out List<QueryDirectoryFileInformation> queryDirectoryFileInformation, handle, searchPattern, FileInformationClass.FileDirectoryInformation);
 
 
@@ -745,12 +745,12 @@ namespace System.IO.Abstractions.SMB
 
         private void Move(string sourceDirName, string destDirName, ISMBCredential sourceCredential, ISMBCredential destinationCredential)
         {
-            if(sourceCredential == null)
+            if (sourceCredential == null)
             {
                 sourceCredential = _credentialProvider.GetSMBCredential(sourceDirName);
             }
 
-            if(destinationCredential == null)
+            if (destinationCredential == null)
             {
                 destinationCredential = _credentialProvider.GetSMBCredential(destDirName);
             }
@@ -767,7 +767,7 @@ namespace System.IO.Abstractions.SMB
 
             var files = EnumerateFiles(sourceDirName, "*", SearchOption.TopDirectoryOnly, sourceCredential);
 
-            foreach(var file in files)
+            foreach (var file in files)
             {
                 var destFilePath = Path.Combine(destDirName, new Uri(file).Segments.Last());
                 SMBFile smbFile = _fileSystem.File as SMBFile;

--- a/System.IO.Abstractions.SMB2/Directory/SMBDirectory.cs
+++ b/System.IO.Abstractions.SMB2/Directory/SMBDirectory.cs
@@ -38,7 +38,10 @@ namespace System.IO.Abstractions.SMB
                 return base.CreateDirectory(path);
             }
 
-            IPAddress ipAddress = path.TryResolveHostnameFromPath();
+            if(!path.TryResolveHostnameFromPath(out var ipAddress))
+            {
+                throw new ArgumentException($"Unable to resolve \"{path.Hostname()}\"");
+            }
 
             NTStatus status = NTStatus.STATUS_SUCCESS;
 
@@ -88,7 +91,10 @@ namespace System.IO.Abstractions.SMB
                 base.Delete(path);
             }
 
-            IPAddress ipAddress = path.TryResolveHostnameFromPath();
+            if (!path.TryResolveHostnameFromPath(out var ipAddress))
+            {
+                throw new ArgumentException($"Unable to resolve \"{path.Hostname()}\"");
+            }
 
             NTStatus status = NTStatus.STATUS_SUCCESS;
 
@@ -138,7 +144,10 @@ namespace System.IO.Abstractions.SMB
 
             if (recursive)
             {
-                IPAddress ipAddress = path.TryResolveHostnameFromPath();
+                if (!path.TryResolveHostnameFromPath(out var ipAddress))
+                {
+                    throw new ArgumentException($"Unable to resolve \"{path.Hostname()}\"");
+                }
 
                 NTStatus status = NTStatus.STATUS_SUCCESS;
 
@@ -235,7 +244,10 @@ namespace System.IO.Abstractions.SMB
                 return base.EnumerateDirectories(path, searchPattern, searchOption);
             }
 
-            IPAddress ipAddress = path.TryResolveHostnameFromPath();
+            if (!path.TryResolveHostnameFromPath(out var ipAddress))
+            {
+                throw new ArgumentException($"Unable to resolve \"{path.Hostname()}\"");
+            }
 
             NTStatus status = NTStatus.STATUS_SUCCESS;
 
@@ -322,7 +334,10 @@ namespace System.IO.Abstractions.SMB
                 return base.EnumerateFiles(path, searchPattern, searchOption);
             }
 
-            IPAddress ipAddress = path.TryResolveHostnameFromPath();
+            if (!path.TryResolveHostnameFromPath(out var ipAddress))
+            {
+                throw new ArgumentException($"Unable to resolve \"{path.Hostname()}\"");
+            }
 
             NTStatus status = NTStatus.STATUS_SUCCESS;
 
@@ -414,7 +429,10 @@ namespace System.IO.Abstractions.SMB
                 return base.EnumerateFileSystemEntries(path, searchPattern, searchOption);
             }
 
-            IPAddress ipAddress = path.TryResolveHostnameFromPath();
+            if (!path.TryResolveHostnameFromPath(out var ipAddress))
+            {
+                throw new ArgumentException($"Unable to resolve \"{path.Hostname()}\"");
+            }
 
             NTStatus status = NTStatus.STATUS_SUCCESS;
 
@@ -477,7 +495,10 @@ namespace System.IO.Abstractions.SMB
                 return base.Exists(path);
             }
 
-            IPAddress ipAddress = path.TryResolveHostnameFromPath();
+            if (!path.TryResolveHostnameFromPath(out var ipAddress))
+            {
+                throw new ArgumentException($"Unable to resolve \"{path.Hostname()}\"");
+            }
 
             NTStatus status = NTStatus.STATUS_SUCCESS;
 

--- a/System.IO.Abstractions.SMB2/Directory/SMBDirectoryInfoFactory.cs
+++ b/System.IO.Abstractions.SMB2/Directory/SMBDirectoryInfoFactory.cs
@@ -39,8 +39,7 @@ namespace System.IO.Abstractions.SMB
                 return null;
             }
 
-            var hostEntry = Dns.GetHostEntry(path.HostName());
-            var ipAddress = hostEntry.AddressList.First(a => a.AddressFamily == Net.Sockets.AddressFamily.InterNetwork);
+            IPAddress ipAddress = path.TryResolveHostnameFromPath();
 
             NTStatus status = NTStatus.STATUS_SUCCESS;
 
@@ -82,8 +81,7 @@ namespace System.IO.Abstractions.SMB
         {
             var path = dirInfo.FullName;
 
-            var hostEntry = Dns.GetHostEntry(path.HostName());
-            var ipAddress = hostEntry.AddressList.First(a => a.AddressFamily == Net.Sockets.AddressFamily.InterNetwork);
+            IPAddress ipAddress = path.TryResolveHostnameFromPath();
 
             NTStatus status = NTStatus.STATUS_SUCCESS;
 

--- a/System.IO.Abstractions.SMB2/Directory/SMBDirectoryInfoFactory.cs
+++ b/System.IO.Abstractions.SMB2/Directory/SMBDirectoryInfoFactory.cs
@@ -11,7 +11,7 @@ namespace System.IO.Abstractions.SMB
     public class SMBDirectoryInfoFactory : IDirectoryInfoFactory
     {
         private readonly IFileSystem _fileSystem;
-        private readonly ISMBCredentialProvider  _credentialProvider;
+        private readonly ISMBCredentialProvider _credentialProvider;
         private readonly ISMBClientFactory _smbClientFactory;
         private SMBDirectory _smbDirectory => _fileSystem.Directory as SMBDirectory;
         private SMBFile _smbFile => _fileSystem.File as SMBFile;
@@ -62,7 +62,7 @@ namespace System.IO.Abstractions.SMB
             var relativePath = path.RelativeSharePath();
 
             ISMBFileStore fileStore = connection.SMBClient.TreeConnect(shareName, out status);
-            
+
             status.HandleStatus();
 
             status = fileStore.CreateFile(out object handle, out FileStatus fileStatus, relativePath, AccessMask.GENERIC_READ, 0, ShareAccess.Read,
@@ -107,12 +107,12 @@ namespace System.IO.Abstractions.SMB
             var relativePath = path.RelativeSharePath();
 
             ISMBFileStore fileStore = connection.SMBClient.TreeConnect(shareName, out status);
-            
+
             status.HandleStatus();
-            
+
             status = fileStore.CreateFile(out object handle, out FileStatus fileStatus, relativePath, AccessMask.GENERIC_WRITE, 0, ShareAccess.Read,
                     CreateDisposition.FILE_OPEN, CreateOptions.FILE_DIRECTORY_FILE, null);
-            
+
             status.HandleStatus();
 
             var fileInfo = dirInfo.ToSMBFileInformation(credential);

--- a/System.IO.Abstractions.SMB2/Directory/SMBDirectoryInfoFactory.cs
+++ b/System.IO.Abstractions.SMB2/Directory/SMBDirectoryInfoFactory.cs
@@ -39,7 +39,10 @@ namespace System.IO.Abstractions.SMB
                 return null;
             }
 
-            IPAddress ipAddress = path.TryResolveHostnameFromPath();
+            if (!path.TryResolveHostnameFromPath(out var ipAddress))
+            {
+                throw new ArgumentException($"Unable to resolve \"{path.Hostname()}\"");
+            }
 
             NTStatus status = NTStatus.STATUS_SUCCESS;
 
@@ -81,7 +84,10 @@ namespace System.IO.Abstractions.SMB
         {
             var path = dirInfo.FullName;
 
-            IPAddress ipAddress = path.TryResolveHostnameFromPath();
+            if (!path.TryResolveHostnameFromPath(out var ipAddress))
+            {
+                throw new ArgumentException($"Unable to resolve \"{path.Hostname()}\"");
+            }
 
             NTStatus status = NTStatus.STATUS_SUCCESS;
 

--- a/System.IO.Abstractions.SMB2/Drive/SMBDriveInfoFactory.cs
+++ b/System.IO.Abstractions.SMB2/Drive/SMBDriveInfoFactory.cs
@@ -42,8 +42,7 @@ namespace System.IO.Abstractions.SMB
             }
 
             var path = credential.Path;
-            var hostEntry = Dns.GetHostEntry(path.HostName());
-            var ipAddress = hostEntry.AddressList.First(a => a.AddressFamily == Net.Sockets.AddressFamily.InterNetwork);
+            IPAddress ipAddress = path.TryResolveHostnameFromPath();
 
             NTStatus status = NTStatus.STATUS_SUCCESS;
 
@@ -92,17 +91,16 @@ namespace System.IO.Abstractions.SMB
                 credentialsToCheck = _smbCredentialProvider.GetSMBCredentials().ToList();
             }
 
-            shareHostNames = credentialsToCheck.Select(smbCredential => smbCredential.Path.HostName()).Distinct().ToList();
+            shareHostNames = credentialsToCheck.Select(smbCredential => smbCredential.Path.Hostname()).Distinct().ToList();
 
             var shareHostShareNames = new Dictionary<string, IEnumerable<string>>();
 
             foreach (var shareHost in shareHostNames)
             {
-                var credential = credentialsToCheck.Where(smbCredential => smbCredential.Path.HostName().Equals(shareHost)).First();
+                var credential = credentialsToCheck.Where(smbCredential => smbCredential.Path.Hostname().Equals(shareHost)).First();
 
                 var path = credential.Path;
-                var hostEntry = Dns.GetHostEntry(path.HostName());
-                var ipAddress = hostEntry.AddressList.First(a => a.AddressFamily == Net.Sockets.AddressFamily.InterNetwork);
+                IPAddress ipAddress = path.TryResolveHostnameFromPath();
 
                 using var connection = SMBConnection.CreateSMBConnection(_smbClientFactory, ipAddress, transport, credential);
 

--- a/System.IO.Abstractions.SMB2/Drive/SMBDriveInfoFactory.cs
+++ b/System.IO.Abstractions.SMB2/Drive/SMBDriveInfoFactory.cs
@@ -42,7 +42,10 @@ namespace System.IO.Abstractions.SMB
             }
 
             var path = credential.Path;
-            IPAddress ipAddress = path.TryResolveHostnameFromPath();
+            if (!path.TryResolveHostnameFromPath(out var ipAddress))
+            {
+                throw new ArgumentException($"Unable to resolve \"{path.Hostname()}\"");
+            }
 
             NTStatus status = NTStatus.STATUS_SUCCESS;
 
@@ -100,7 +103,10 @@ namespace System.IO.Abstractions.SMB
                 var credential = credentialsToCheck.Where(smbCredential => smbCredential.Path.Hostname().Equals(shareHost)).First();
 
                 var path = credential.Path;
-                IPAddress ipAddress = path.TryResolveHostnameFromPath();
+                if (!path.TryResolveHostnameFromPath(out var ipAddress))
+                {
+                    throw new ArgumentException($"Unable to resolve \"{path.Hostname()}\"");
+                }
 
                 using var connection = SMBConnection.CreateSMBConnection(_smbClientFactory, ipAddress, transport, credential);
 

--- a/System.IO.Abstractions.SMB2/Extensions/PathExtensions.cs
+++ b/System.IO.Abstractions.SMB2/Extensions/PathExtensions.cs
@@ -44,30 +44,31 @@ namespace System.IO.Abstractions.SMB
             return uri.Host;
         }
 
-        public static IPAddress TryResolveHostnameFromPath(this string path)
+        public static bool TryResolveHostnameFromPath(this string path, out IPAddress ipAddress)
         {
-            return path.Hostname().TryResolveHostname();
+            return path.Hostname().TryResolveHostname(out ipAddress);
         }
 
-        public static IPAddress TryResolveHostname(this string hostnameOrAddress)
+        public static bool TryResolveHostname(this string hostnameOrAddress, out IPAddress ipAddress)
         {
-            IPAddress ipAddress;
+            var parsedIPAddress = IPAddress.TryParse(hostnameOrAddress, out ipAddress);
             
-            if(IPAddress.TryParse(hostnameOrAddress, out ipAddress))
+            if (parsedIPAddress)
             {
-                return ipAddress;
+                return true;
             }
 
             try
             {
                 var hostEntry = Dns.GetHostEntry(hostnameOrAddress);
                 ipAddress = hostEntry.AddressList.First(a => a.AddressFamily == Net.Sockets.AddressFamily.InterNetwork);
-
-                return ipAddress;
+                
+                return true;
             }
             catch(Exception ex)
             {
-                throw new AggregateException("Unable to resolve hostname", ex);
+                ipAddress = IPAddress.None;
+                return false;
             }
         }
 

--- a/System.IO.Abstractions.SMB2/Extensions/PathExtensions.cs
+++ b/System.IO.Abstractions.SMB2/Extensions/PathExtensions.cs
@@ -7,7 +7,6 @@ namespace System.IO.Abstractions.SMB
     public static class PathExtensions
     {
         static readonly string[] pathSeperators = { @"\", "/" };
-        static readonly char s = IO.Path.DirectorySeparatorChar;
 
         public static bool IsValidSharePath(this string path)
         {
@@ -33,7 +32,7 @@ namespace System.IO.Abstractions.SMB
             }
             else
             {
-                return $"{s}{s}{path.HostName()}{s}{shareName}";
+                return $@"\\{path.HostName()}\{shareName}";
             }
         }
 
@@ -59,7 +58,7 @@ namespace System.IO.Abstractions.SMB
             if (uri.Scheme.Equals("smb"))
                 sharePath = $"{uri.Scheme}://{uri.Host}/{uri.Segments[1].RemoveAnySeperators()}";
             else if (uri.IsUnc)
-                sharePath = $@"{s}{s}{uri.Host}{s}{uri.Segments[1].RemoveAnySeperators()}";
+                sharePath = $@"\\{uri.Host}\{uri.Segments[1].RemoveAnySeperators()}";
 
             return sharePath;
         }

--- a/System.IO.Abstractions.SMB2/Extensions/PathExtensions.cs
+++ b/System.IO.Abstractions.SMB2/Extensions/PathExtensions.cs
@@ -28,7 +28,7 @@ namespace System.IO.Abstractions.SMB
         public static string BuildSharePath(this string path, string shareName)
         {
             var uri = new Uri(path);
-            if(!uri.IsUnc)
+            if (!uri.IsUnc)
             {
                 return $"smb://{path.Hostname()}/{shareName}";
             }
@@ -52,7 +52,7 @@ namespace System.IO.Abstractions.SMB
         public static bool TryResolveHostname(this string hostnameOrAddress, out IPAddress ipAddress)
         {
             var parsedIPAddress = IPAddress.TryParse(hostnameOrAddress, out ipAddress);
-            
+
             if (parsedIPAddress)
             {
                 return true;
@@ -62,10 +62,10 @@ namespace System.IO.Abstractions.SMB
             {
                 var hostEntry = Dns.GetHostEntry(hostnameOrAddress);
                 ipAddress = hostEntry.AddressList.First(a => a.AddressFamily == Net.Sockets.AddressFamily.InterNetwork);
-                
+
                 return true;
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
                 ipAddress = IPAddress.None;
                 return false;
@@ -123,9 +123,9 @@ namespace System.IO.Abstractions.SMB
         {
             foreach (var pathSeperator in pathSeperators)
             {
-                if(input.StartsWith(pathSeperator))
+                if (input.StartsWith(pathSeperator))
                 {
-                    input = input.Remove(0,1);
+                    input = input.Remove(0, 1);
                 }
             }
 

--- a/System.IO.Abstractions.SMB2/File/SMBFile.cs
+++ b/System.IO.Abstractions.SMB2/File/SMBFile.cs
@@ -222,8 +222,7 @@ namespace System.IO.Abstractions.SMB
                 return;
             }
 
-            var hostEntry = Dns.GetHostEntry(path.HostName());
-            var ipAddress = hostEntry.AddressList.First(a => a.AddressFamily == Net.Sockets.AddressFamily.InterNetwork);
+            IPAddress ipAddress = path.TryResolveHostnameFromPath();
 
             NTStatus status = NTStatus.STATUS_SUCCESS;
 
@@ -266,8 +265,7 @@ namespace System.IO.Abstractions.SMB
                 return base.Exists(path);
             }
 
-            var hostEntry = Dns.GetHostEntry(path.HostName());
-            var ipAddress = hostEntry.AddressList.First(a => a.AddressFamily == Net.Sockets.AddressFamily.InterNetwork);
+            IPAddress ipAddress = path.TryResolveHostnameFromPath();
 
             NTStatus status = NTStatus.STATUS_SUCCESS;
 
@@ -476,8 +474,7 @@ namespace System.IO.Abstractions.SMB
 
         internal Stream Open(string path, FileMode mode, FileAccess access, FileShare share, FileOptions fileOptions, ISMBCredential credential)
         {
-            var hostEntry = Dns.GetHostEntry(path.HostName());
-            var ipAddress = hostEntry.AddressList.First(a => a.AddressFamily == Net.Sockets.AddressFamily.InterNetwork);
+            IPAddress ipAddress = path.TryResolveHostnameFromPath();
 
             NTStatus status = NTStatus.STATUS_SUCCESS;
 

--- a/System.IO.Abstractions.SMB2/File/SMBFile.cs
+++ b/System.IO.Abstractions.SMB2/File/SMBFile.cs
@@ -222,7 +222,10 @@ namespace System.IO.Abstractions.SMB
                 return;
             }
 
-            IPAddress ipAddress = path.TryResolveHostnameFromPath();
+            if (!path.TryResolveHostnameFromPath(out var ipAddress))
+            {
+                throw new ArgumentException($"Unable to resolve \"{path.Hostname()}\"");
+            }
 
             NTStatus status = NTStatus.STATUS_SUCCESS;
 
@@ -235,7 +238,7 @@ namespace System.IO.Abstractions.SMB
                 var directoryPath = Path.GetDirectoryName(relativePath);
 
                 ISMBFileStore fileStore = connection.SMBClient.TreeConnect(shareName, out status);
-                
+
                 status.HandleStatus();
 
                 int attempts = 0;
@@ -265,7 +268,10 @@ namespace System.IO.Abstractions.SMB
                 return base.Exists(path);
             }
 
-            IPAddress ipAddress = path.TryResolveHostnameFromPath();
+            if (!path.TryResolveHostnameFromPath(out var ipAddress))
+            {
+                throw new ArgumentException($"Unable to resolve \"{path.Hostname()}\"");
+            }
 
             NTStatus status = NTStatus.STATUS_SUCCESS;
 
@@ -278,9 +284,9 @@ namespace System.IO.Abstractions.SMB
                 var directoryPath = Path.GetDirectoryName(relativePath);
 
                 ISMBFileStore fileStore = connection.SMBClient.TreeConnect(shareName, out status);
-                
+
                 status.HandleStatus();
-                
+
                 status = fileStore.CreateFile(out object handle, out FileStatus fileStatus, directoryPath, AccessMask.GENERIC_READ, 0, ShareAccess.Read,
                     CreateDisposition.FILE_OPEN, CreateOptions.FILE_DIRECTORY_FILE, null);
 
@@ -474,7 +480,10 @@ namespace System.IO.Abstractions.SMB
 
         internal Stream Open(string path, FileMode mode, FileAccess access, FileShare share, FileOptions fileOptions, ISMBCredential credential)
         {
-            IPAddress ipAddress = path.TryResolveHostnameFromPath();
+            if (!path.TryResolveHostnameFromPath(out var ipAddress))
+            {
+                throw new ArgumentException($"Unable to resolve \"{path.Hostname()}\"");
+            }
 
             NTStatus status = NTStatus.STATUS_SUCCESS;
 
@@ -537,7 +546,7 @@ namespace System.IO.Abstractions.SMB
             var relativePath = path.RelativeSharePath();
 
             ISMBFileStore fileStore = connection.SMBClient.TreeConnect(shareName, out status);
-            
+
             status.HandleStatus();
 
             switch (mode)

--- a/System.IO.Abstractions.SMB2/File/SMBFileInfo.cs
+++ b/System.IO.Abstractions.SMB2/File/SMBFileInfo.cs
@@ -100,7 +100,7 @@ namespace System.IO.Abstractions.SMB
 
         public StreamWriter CreateText()
         {
-            var streamWriter =  _file.CreateText(FullName);
+            var streamWriter = _file.CreateText(FullName);
             Exists = true;
             return streamWriter;
         }
@@ -135,7 +135,7 @@ namespace System.IO.Abstractions.SMB
 
         public Stream Open(FileMode mode, FileAccess access)
         {
-            var stream =  _file.Open(FullName, mode, access);
+            var stream = _file.Open(FullName, mode, access);
             Exists = true;
             return stream;
         }
@@ -149,7 +149,7 @@ namespace System.IO.Abstractions.SMB
 
         public Stream OpenRead()
         {
-            var stream =  _file.OpenRead(FullName);
+            var stream = _file.OpenRead(FullName);
             Exists = true;
             return stream;
         }

--- a/System.IO.Abstractions.SMB2/File/SMBFileInfoFactory.cs
+++ b/System.IO.Abstractions.SMB2/File/SMBFileInfoFactory.cs
@@ -36,8 +36,7 @@ namespace System.IO.Abstractions.SMB
                 return null;
             }
 
-            var hostEntry = Dns.GetHostEntry(path.HostName());
-            var ipAddress = hostEntry.AddressList.First(a => a.AddressFamily == Net.Sockets.AddressFamily.InterNetwork);
+            IPAddress ipAddress = path.TryResolveHostnameFromPath();
 
             NTStatus status = NTStatus.STATUS_SUCCESS;
 
@@ -76,8 +75,7 @@ namespace System.IO.Abstractions.SMB
         {
             var path = fileInfo.FullName;
 
-            var hostEntry = Dns.GetHostEntry(path.HostName());
-            var ipAddress = hostEntry.AddressList.First(a => a.AddressFamily == Net.Sockets.AddressFamily.InterNetwork);
+            IPAddress ipAddress = path.TryResolveHostnameFromPath();
 
             NTStatus status = NTStatus.STATUS_SUCCESS;
 

--- a/System.IO.Abstractions.SMB2/File/SMBFileInfoFactory.cs
+++ b/System.IO.Abstractions.SMB2/File/SMBFileInfoFactory.cs
@@ -36,7 +36,10 @@ namespace System.IO.Abstractions.SMB
                 return null;
             }
 
-            IPAddress ipAddress = path.TryResolveHostnameFromPath();
+            if (!path.TryResolveHostnameFromPath(out var ipAddress))
+            {
+                throw new ArgumentException($"Unable to resolve \"{path.Hostname()}\"");
+            }
 
             NTStatus status = NTStatus.STATUS_SUCCESS;
 
@@ -75,7 +78,10 @@ namespace System.IO.Abstractions.SMB
         {
             var path = fileInfo.FullName;
 
-            IPAddress ipAddress = path.TryResolveHostnameFromPath();
+            if (!path.TryResolveHostnameFromPath(out var ipAddress))
+            {
+                throw new ArgumentException($"Unable to resolve \"{path.Hostname()}\"");
+            }
 
             NTStatus status = NTStatus.STATUS_SUCCESS;
 

--- a/System.IO.Abstractions.SMB2/FileSystem/SMBFileSystemInformation.cs
+++ b/System.IO.Abstractions.SMB2/FileSystem/SMBFileSystemInformation.cs
@@ -21,7 +21,7 @@ namespace System.IO.Abstractions.SMB
             var relativePath = path.RelativeSharePath();
 
             NTStatus status = NTStatus.STATUS_SUCCESS;
-        
+
             if (status == NTStatus.STATUS_SUCCESS)
             {
                 fileStore.GetFileSystemInformation(out var fileFsVolumeInformation, FileSystemInformationClass.FileFsVolumeInformation);

--- a/System.IO.Abstractions.SMB2/FileSystem/SMBFileSystemWatcherFactory.cs
+++ b/System.IO.Abstractions.SMB2/FileSystem/SMBFileSystemWatcherFactory.cs
@@ -5,7 +5,7 @@ namespace System.IO.Abstractions.SMB
     {
         public new IFileSystemWatcher FromPath(string path)
         {
-            if(path.IsSmbPath())
+            if (path.IsSmbPath())
             {
                 return base.FromPath(path);
             }

--- a/System.IO.Abstractions.SMB2/Stream/SMBFileStreamFactory.cs
+++ b/System.IO.Abstractions.SMB2/Stream/SMBFileStreamFactory.cs
@@ -70,7 +70,7 @@ namespace System.IO.Abstractions.SMB
                 return new FileStream(path, mode, access, share, bufferSize, useAsync);
             }
 
-            if(useAsync == false)
+            if (useAsync == false)
             {
                 return new BufferedStream(_fileSystem.File.Open(path, mode, access, share), bufferSize);
             }
@@ -82,7 +82,7 @@ namespace System.IO.Abstractions.SMB
 
         public Stream Create(SafeFileHandle handle, FileAccess access)
         {
-            throw new NotSupportedException();    
+            throw new NotSupportedException();
         }
 
         public Stream Create(SafeFileHandle handle, FileAccess access, int bufferSize)


### PR DESCRIPTION
- Fix UNC Path building in `PathExtensions`, revert a change to build UNC paths with platform specific `Path.DirectorySeparatorChar`.

- Add PathExtension to `TryResolveHostnameFromPath` and `TryResolveHostname` 
    - ` System.Net.Internals.SocketExceptionFactory+ExtendedSocketException : Name or service not known`  was being thrown for me when trying to `Dns.GetHostEntry()` a `string` ip address
    - `System.Net.Internals.SocketExceptionFactory+ExtendedSocketException : Resource temporarily unavailable` was being thrown when unable to resolve a hostname