### PR TITLE
Update System.IO.Abstractions to 9.0.6 and remove unused properties and methods

### DIFF
--- a/SmbAbstraction/Directory/SMBDirectoryInfo.cs
+++ b/SmbAbstraction/Directory/SMBDirectoryInfo.cs
@@ -338,10 +338,5 @@ namespace SmbAbstraction
 
             return fileBasicInformation;
         }
-
-        public override void Create(DirectorySecurity directorySecurity)
-        {
-            throw new NotImplementedException();
-        }
     }
 }

--- a/SmbAbstraction/Path/SMBPath.cs
+++ b/SmbAbstraction/Path/SMBPath.cs
@@ -22,12 +22,6 @@ namespace SmbAbstraction
             get { return base.DirectorySeparatorChar; }
         }
 
-        [Obsolete("Please use GetInvalidPathChars or GetInvalidFileNameChars instead.")]
-        public override char[] InvalidPathChars
-        {
-            get { return base.InvalidPathChars; }
-        }
-
         public override char PathSeparator
         {
             get { return base.PathSeparator; }

--- a/SmbAbstraction/SmbAbstraction.csproj
+++ b/SmbAbstraction/SmbAbstraction.csproj
@@ -29,7 +29,7 @@
     <LangVersion>latestmajor</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.IO.Abstractions" Version="9.0.5" />
+    <PackageReference Include="System.IO.Abstractions" Version="9.0.6" />
     <PackageReference Include="NuGet.Build.Packaging" Version="0.2.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Update System.IO.Abstractions to 9.0.6

Remove `InvalidPathChars` property from SMBPath as it is no longer used.

Remove `Create(DirectorySecurity directorySecurity)` method from SMBDirectoryInfo as it is no longer used