### PR TITLE
Update System.IO.Abstractions to 10.0.1

### DIFF
--- a/SmbAbstraction/SmbAbstraction.csproj
+++ b/SmbAbstraction/SmbAbstraction.csproj
@@ -29,7 +29,7 @@
     <LangVersion>latestmajor</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.IO.Abstractions" Version="9.0.6" />
+    <PackageReference Include="System.IO.Abstractions" Version="10.0.1" />
     <PackageReference Include="NuGet.Build.Packaging" Version="0.2.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Update System.IO.Abstractions to 10.0.1. 

Which adds a missing FileStream constructor to IFileStreamFactory as indicated in this PR 
https://github.com/System-IO-Abstractions/System.IO.Abstractions/pull/566