### PR TITLE
 Fix null refrence when initializing DirectoryInfo from non share paths

### DIFF
--- a/SmbAbstraction.Tests.Integration/Directory/DirectoryTests.Variations.cs
+++ b/SmbAbstraction.Tests.Integration/Directory/DirectoryTests.Variations.cs
@@ -15,4 +15,9 @@ namespace SmbAbstraction.Tests.Integration.Directory
     {
         public SmbUriTests(SmbUriFixture fixture) : base(fixture) { }
     }
+
+    public class BaseFileSystemTests : DirectoryTests, IClassFixture<BaseFileSystemFixture>
+    {
+        public BaseFileSystemTests(BaseFileSystemFixture fixture) : base(fixture) { }
+    }
 }

--- a/SmbAbstraction.Tests.Integration/Directory/DirectoryTests.cs
+++ b/SmbAbstraction.Tests.Integration/Directory/DirectoryTests.cs
@@ -78,5 +78,19 @@ namespace SmbAbstraction.Tests.Integration.Directory
 
             Assert.True(files.Count >= 0); //Include 0 in case directory is empty. If an exception is thrown, the test will fail.
         }
+
+        [Fact]
+        [Trait("Category", "Integration")]
+        public void CheckDirectoryExists()
+        {
+            var credentials = _fixture.ShareCredentials;
+            var share = _fixture.Shares.First();
+            var rootPath = share.GetRootPath(_fixture.PathType);
+            var directory = _fileSystem.Path.Combine(rootPath, share.Directories.First());
+
+            using var credential = new SMBCredential(credentials.Domain, credentials.Username, credentials.Password, rootPath, _fixture.SMBCredentialProvider);
+            
+            Assert.True(_fileSystem.Directory.Exists(directory));
+        }
     }
 }

--- a/SmbAbstraction.Tests.Integration/Directory/DirectoryTests.cs
+++ b/SmbAbstraction.Tests.Integration/Directory/DirectoryTests.cs
@@ -30,10 +30,8 @@ namespace SmbAbstraction.Tests.Integration.Directory
         public void CanCreateDirectoryInRootDirectory()
         {
             var credentials = _fixture.ShareCredentials;
-            var share = _fixture.Shares.First();
-            var rootPath = share.GetRootPath(_fixture.PathType);
 
-            createdTestDirectoryPath = _fileSystem.Path.Combine(rootPath, $"test_directory-{DateTime.Now.ToFileTimeUtc()}");
+            createdTestDirectoryPath = _fileSystem.Path.Combine(_fixture.RootPath, $"test_directory-{DateTime.Now.ToFileTimeUtc()}");
 
             using var credential = new SMBCredential(credentials.Domain, credentials.Username, credentials.Password, createdTestDirectoryPath, _fixture.SMBCredentialProvider);
 
@@ -49,10 +47,8 @@ namespace SmbAbstraction.Tests.Integration.Directory
         public void CanCreateNestedDirectoryInRootDirectory()
         {
             var credentials = _fixture.ShareCredentials;
-            var share = _fixture.Shares.First();
-            var rootPath = share.GetRootPath(_fixture.PathType);
 
-            var parentDirectoryPath = _fileSystem.Path.Combine(rootPath, $"test_directory_parent-{DateTime.Now.ToFileTimeUtc()}");
+            var parentDirectoryPath = _fileSystem.Path.Combine(_fixture.RootPath, $"test_directory_parent-{DateTime.Now.ToFileTimeUtc()}");
             createdTestDirectoryPath = _fileSystem.Path.Combine(parentDirectoryPath, $"test_directory_child-{DateTime.Now.ToFileTimeUtc()}");
 
             using var credential = new SMBCredential(credentials.Domain, credentials.Username, credentials.Password, createdTestDirectoryPath, _fixture.SMBCredentialProvider);
@@ -69,12 +65,10 @@ namespace SmbAbstraction.Tests.Integration.Directory
         public void CanEnumerateFilesRootDirectory()
         {
             var credentials = _fixture.ShareCredentials;
-            var share = _fixture.Shares.First();
-            var rootPath = share.GetRootPath(_fixture.PathType);
 
-            using var credential = new SMBCredential(credentials.Domain, credentials.Username, credentials.Password, rootPath, _fixture.SMBCredentialProvider);
+            using var credential = new SMBCredential(credentials.Domain, credentials.Username, credentials.Password, _fixture.RootPath, _fixture.SMBCredentialProvider);
 
-            var files = _fileSystem.Directory.EnumerateFiles(rootPath, "*").ToList();
+            var files = _fileSystem.Directory.EnumerateFiles(_fixture.RootPath, "*").ToList();
 
             Assert.True(files.Count >= 0); //Include 0 in case directory is empty. If an exception is thrown, the test will fail.
         }
@@ -84,11 +78,9 @@ namespace SmbAbstraction.Tests.Integration.Directory
         public void CheckDirectoryExists()
         {
             var credentials = _fixture.ShareCredentials;
-            var share = _fixture.Shares.First();
-            var rootPath = share.GetRootPath(_fixture.PathType);
-            var directory = _fileSystem.Path.Combine(rootPath, share.Directories.First());
+            var directory = _fileSystem.Path.Combine(_fixture.RootPath, _fixture.Directories.First());
 
-            using var credential = new SMBCredential(credentials.Domain, credentials.Username, credentials.Password, rootPath, _fixture.SMBCredentialProvider);
+            using var credential = new SMBCredential(credentials.Domain, credentials.Username, credentials.Password, _fixture.RootPath, _fixture.SMBCredentialProvider);
             
             Assert.True(_fileSystem.Directory.Exists(directory));
         }

--- a/SmbAbstraction.Tests.Integration/DirectoryInfo/DirectoryInfoTests.Variations.cs
+++ b/SmbAbstraction.Tests.Integration/DirectoryInfo/DirectoryInfoTests.Variations.cs
@@ -15,4 +15,9 @@ namespace SmbAbstraction.Tests.Integration.DirectoryInfo
     {
         public SmbUriTests(SmbUriFixture fixture) : base(fixture) { }
     }
+
+    public class BaseFileSystemTests : DirectoryInfoTests, IClassFixture<BaseFileSystemFixture>
+    {
+        public BaseFileSystemTests(BaseFileSystemFixture fixture) : base(fixture) { }
+    }
 }

--- a/SmbAbstraction.Tests.Integration/DirectoryInfo/DirectoryInfoTests.cs
+++ b/SmbAbstraction.Tests.Integration/DirectoryInfo/DirectoryInfoTests.cs
@@ -18,26 +18,38 @@ namespace SmbAbstraction.Tests.Integration.DirectoryInfo
             _fileSystem = _fixture.FileSystem;
         }
 
+
         [Fact]
         [Trait("Category", "Integration")]
-        public void MoveLocalDirectoryToUncShare()
+        public void CanCreateNewDirectoryInfo()
         {
             var credentials = _fixture.ShareCredentials;
-            var share = _fixture.Shares.First();
-            var rootPath = share.GetRootPath(_fixture.PathType);
-            var directory = _fileSystem.Path.Combine(rootPath, share.Directories.First());
+            var directory = _fileSystem.Path.Combine(_fixture.RootPath, _fixture.Directories.First());
+
+            using var credential = new SMBCredential(credentials.Domain, credentials.Username, credentials.Password, directory, _fixture.SMBCredentialProvider);
+
+            var directoryInfo = _fileSystem.DirectoryInfo.FromDirectoryName(directory);
+
+            Assert.NotNull(directoryInfo);
+        }
+
+        [Fact]
+        [Trait("Category", "Integration")]
+        public void CheckMoveDirectory()
+        {
+            var credentials = _fixture.ShareCredentials;
+            var directory = _fileSystem.Path.Combine(_fixture.RootPath, _fixture.Directories.First());
             var newDirectory = _fileSystem.Path.Combine(directory, $"{DateTime.Now.ToFileTimeUtc()}");
 
             using var credential = new SMBCredential(credentials.Domain, credentials.Username, credentials.Password, directory, _fixture.SMBCredentialProvider);
 
-            var createDirectoryPath = _fileSystem.Path.Combine(rootPath, $"test-move-local-directory-{DateTime.Now.ToFileTimeUtc()}");
+            var createDirectoryPath = _fileSystem.Path.Combine(_fixture.RootPath, $"test-move-local-directory-{DateTime.Now.ToFileTimeUtc()}");
             var directoryInfo = _fileSystem.Directory.CreateDirectory(createDirectoryPath);
             
             directoryInfo.MoveTo(newDirectory);
 
             Assert.True(_fileSystem.Directory.Exists(newDirectory));
 
-            _fileSystem.Directory.Delete(directoryInfo.FullName);
             _fileSystem.Directory.Delete(newDirectory);
         }
     }

--- a/SmbAbstraction.Tests.Integration/DriveInfo/DriveInfoTests.Variations.cs
+++ b/SmbAbstraction.Tests.Integration/DriveInfo/DriveInfoTests.Variations.cs
@@ -15,4 +15,9 @@ namespace SmbAbstraction.Tests.Integration.DriveInfo
     {
         public SmbUriTests(SmbUriFixture fixture) : base(fixture) { }
     }
+
+    public class BaseFileSystemTests : DriveInfoTests, IClassFixture<BaseFileSystemFixture>
+    {
+        public BaseFileSystemTests(BaseFileSystemFixture fixture) : base(fixture) { }
+    }
 }

--- a/SmbAbstraction.Tests.Integration/DriveInfo/DriveInfoTests.cs
+++ b/SmbAbstraction.Tests.Integration/DriveInfo/DriveInfoTests.cs
@@ -20,27 +20,36 @@ namespace SmbAbstraction.Tests.Integration.DriveInfo
         public void FromDriveName_ReturnsNotNull()
         {
             var credentials = _fixture.ShareCredentials;
-            var share = _fixture.Shares.FirstOrDefault();
-            var rootPath = share.GetRootPath(_fixture.PathType);
 
-            _fixture.SMBCredentialProvider.AddSMBCredential(new SMBCredential(credentials.Domain, credentials.Username, credentials.Password, rootPath, _fixture.SMBCredentialProvider));
+            _fixture.SMBCredentialProvider.AddSMBCredential(new SMBCredential(credentials.Domain, credentials.Username, credentials.Password, _fixture.RootPath, _fixture.SMBCredentialProvider));
 
             var smbDriveInfoFactory = new SMBDriveInfoFactory(_fileSystem, _fixture.SMBCredentialProvider, _fixture.SMBClientFactory, 65536);
 
-            var shareInfo = smbDriveInfoFactory.FromDriveName(share.ShareName);
+            var shareInfo = smbDriveInfoFactory.FromDriveName(_fixture.ShareName);
 
             Assert.NotNull(shareInfo);
         }
 
         [Fact]
         [Trait("Category", "Integration")]
-        public void GetDrives_ReturnsNotNull()
+        public void GetDrives_WithCredentials_ReturnsNotNull()
         {
             var credentials = _fixture.ShareCredentials;
-            var share = _fixture.Shares.FirstOrDefault();
-            var rootPath = share.GetRootPath(_fixture.PathType);
+            
+            _fixture.SMBCredentialProvider.AddSMBCredential(new SMBCredential(credentials.Domain, credentials.Username, credentials.Password, _fixture.RootPath, _fixture.SMBCredentialProvider));
 
-            _fixture.SMBCredentialProvider.AddSMBCredential(new SMBCredential(credentials.Domain, credentials.Username, credentials.Password, rootPath, _fixture.SMBCredentialProvider));
+            var smbDriveInfoFactory = new SMBDriveInfoFactory(_fileSystem, _fixture.SMBCredentialProvider, _fixture.SMBClientFactory, 65536);
+
+            var shares = smbDriveInfoFactory.GetDrives();
+
+            Assert.NotNull(shares);
+        }
+
+        [Fact]
+        [Trait("Category", "Integration")]
+        public void GetDrives_WithNoCredentials_ReturnsNotNull()
+        {
+            var credentials = _fixture.ShareCredentials;
 
             var smbDriveInfoFactory = new SMBDriveInfoFactory(_fileSystem, _fixture.SMBCredentialProvider, _fixture.SMBClientFactory, 65536);
 

--- a/SmbAbstraction.Tests.Integration/File/FileTests.Variations.cs
+++ b/SmbAbstraction.Tests.Integration/File/FileTests.Variations.cs
@@ -1,0 +1,18 @@
+﻿using SmbAbstraction.Tests.Integration.Fixtures;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace SmbAbstraction.Tests.Integration.File
+{
+    public class UncPathTests : FileTests, IClassFixture<UncPathFixture>
+    {
+        public UncPathTests(UncPathFixture fixture) : base(fixture) { }
+    }
+
+    public class SmbUriTests : FileTests, IClassFixture<SmbUriFixture>
+    {
+        public SmbUriTests(SmbUriFixture fixture) : base(fixture) { }
+    }
+}

--- a/SmbAbstraction.Tests.Integration/File/FileTests.Variations.cs
+++ b/SmbAbstraction.Tests.Integration/File/FileTests.Variations.cs
@@ -15,4 +15,9 @@ namespace SmbAbstraction.Tests.Integration.File
     {
         public SmbUriTests(SmbUriFixture fixture) : base(fixture) { }
     }
+
+    public class BaseFileSystemTests : FileTests, IClassFixture<BaseFileSystemFixture>
+    {
+        public BaseFileSystemTests(BaseFileSystemFixture fixture) : base(fixture) { }
+    }
 }

--- a/SmbAbstraction.Tests.Integration/File/FileTests.cs
+++ b/SmbAbstraction.Tests.Integration/File/FileTests.cs
@@ -25,9 +25,7 @@ namespace SmbAbstraction.Tests.Integration.File
         {
             var tempFileName = $"temp-{DateTime.Now.ToFileTimeUtc()}.txt";
             var credentials = _fixture.ShareCredentials;
-            var share = _fixture.Shares.First();
-            var rootPath = share.GetRootPath(_fixture.PathType);
-            var directory = _fileSystem.Path.Combine(rootPath, share.Directories.First());
+            var directory = _fileSystem.Path.Combine(_fixture.RootPath, _fixture.Directories.First());
             var tempFilePath = _fileSystem.Path.Combine(_fixture.LocalTempDirectory, tempFileName);
 
             using var credential = new SMBCredential(credentials.Domain, credentials.Username, credentials.Password, directory, _fixture.SMBCredentialProvider);

--- a/SmbAbstraction.Tests.Integration/File/FileTests.cs
+++ b/SmbAbstraction.Tests.Integration/File/FileTests.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Abstractions;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace SmbAbstraction.Tests.Integration.File
+{
+    public abstract class FileTests
+    {
+        readonly TestFixture _fixture;
+        private IFileSystem _fileSystem;
+
+        public FileTests(TestFixture fixture)
+        {
+            _fixture = fixture;
+            _fileSystem = _fixture.FileSystem;
+        }
+
+        [Fact]
+        [Trait("Category", "Integration")]
+        public void CheckDeleteCompletes()
+        {
+            var tempFileName = $"temp-{DateTime.Now.ToFileTimeUtc()}.txt";
+            var credentials = _fixture.ShareCredentials;
+            var share = _fixture.Shares.First();
+            var rootPath = share.GetRootPath(_fixture.PathType);
+            var directory = _fileSystem.Path.Combine(rootPath, share.Directories.First());
+            var tempFilePath = _fileSystem.Path.Combine(_fixture.LocalTempDirectory, tempFileName);
+
+            using var credential = new SMBCredential(credentials.Domain, credentials.Username, credentials.Password, directory, _fixture.SMBCredentialProvider);
+
+            if (!_fileSystem.File.Exists(tempFilePath))
+            {
+                using (var streamWriter = new StreamWriter(_fileSystem.File.Create(tempFilePath)))
+                {
+                    streamWriter.WriteLine("Test");
+                }
+            }
+
+            var fileInfo = _fileSystem.FileInfo.FromFileName(tempFilePath);
+            fileInfo = fileInfo.CopyTo(_fileSystem.Path.Combine(directory, tempFileName));
+
+            fileInfo.Delete();
+
+            _fileSystem.File.Delete(tempFilePath);
+        }
+    }
+}

--- a/SmbAbstraction.Tests.Integration/FileInfo/FileInfoTests.Variations.cs
+++ b/SmbAbstraction.Tests.Integration/FileInfo/FileInfoTests.Variations.cs
@@ -15,4 +15,9 @@ namespace SmbAbstraction.Tests.Integration.FileInfo
     {
         public SmbUriTests(SmbUriFixture fixture) : base(fixture) { }
     }
+
+    public class BaseFileSystemTests : FileInfoTests, IClassFixture<BaseFileSystemFixture>
+    {
+        public BaseFileSystemTests(BaseFileSystemFixture fixture) : base(fixture) { }
+    }
 }

--- a/SmbAbstraction.Tests.Integration/FileInfo/FileInfoTests.cs
+++ b/SmbAbstraction.Tests.Integration/FileInfo/FileInfoTests.cs
@@ -19,13 +19,26 @@ namespace SmbAbstraction.Tests.Integration.FileInfo
 
         [Fact]
         [Trait("Category", "Integration")]
+        public void CanCreateFileInfo()
+        {
+            var credentials = _fixture.ShareCredentials;
+            var directory = _fileSystem.Path.Combine(_fixture.RootPath, _fixture.Directories.First());
+            var filePath = _fileSystem.Path.Combine(_fixture.RootPath, _fixture.Files.First());
+
+            using var credential = new SMBCredential(credentials.Domain, credentials.Username, credentials.Password, directory, _fixture.SMBCredentialProvider);
+
+            var fileInfo = _fileSystem.FileInfo.FromFileName(filePath);
+
+            Assert.NotNull(fileInfo);
+        }
+
+        [Fact]
+        [Trait("Category", "Integration")]
         public void CopyFromLocalDirectoryToShareDirectory()
         {
             var tempFileName = $"temp-{DateTime.Now.ToFileTimeUtc()}.txt";
             var credentials = _fixture.ShareCredentials;
-            var share = _fixture.Shares.First();
-            var rootPath = share.GetRootPath(_fixture.PathType);
-            var directory = _fileSystem.Path.Combine(rootPath, share.Directories.First());
+            var directory = _fileSystem.Path.Combine(_fixture.RootPath, _fixture.Directories.First());
             var tempFilePath = _fileSystem.Path.Combine(_fixture.LocalTempDirectory, tempFileName);
 
             using var credential = new SMBCredential(credentials.Domain, credentials.Username, credentials.Password, directory, _fixture.SMBCredentialProvider);
@@ -53,9 +66,7 @@ namespace SmbAbstraction.Tests.Integration.FileInfo
         {
             var tempFileName = $"temp-{DateTime.Now.ToFileTimeUtc()}.txt";
             var credentials = _fixture.ShareCredentials;
-            var share = _fixture.Shares.First();
-            var rootPath = share.GetRootPath(_fixture.PathType);
-            var directory = _fileSystem.Path.Combine(rootPath, share.Directories.First());
+            var directory = _fileSystem.Path.Combine(_fixture.RootPath, _fixture.Directories.First());
             var tempFilePath = _fileSystem.Path.Combine(_fixture.LocalTempDirectory, tempFileName);
 
             var byteArray = new byte[100];
@@ -88,10 +99,8 @@ namespace SmbAbstraction.Tests.Integration.FileInfo
         public void CheckFileExists()
         {
             var credentials = _fixture.ShareCredentials;
-            var share = _fixture.Shares.First();
-            var rootPath = share.GetRootPath(_fixture.PathType);
-            var directory = _fileSystem.Path.Combine(rootPath, share.Directories.First());
-            var filePath = _fileSystem.Path.Combine(rootPath, share.Files.First());
+            var directory = _fileSystem.Path.Combine(_fixture.RootPath, _fixture.Directories.First());
+            var filePath = _fileSystem.Path.Combine(_fixture.RootPath, _fixture.Files.First());
 
             using var credential = new SMBCredential(credentials.Domain, credentials.Username, credentials.Password, directory, _fixture.SMBCredentialProvider);
 
@@ -105,10 +114,8 @@ namespace SmbAbstraction.Tests.Integration.FileInfo
         public void CheckFileExtensionMatches()
         {
             var credentials = _fixture.ShareCredentials;
-            var share = _fixture.Shares.First();
-            var rootPath = share.GetRootPath(_fixture.PathType);
-            var directory = _fileSystem.Path.Combine(rootPath, share.Directories.First());
-            var filePath = _fileSystem.Path.Combine(rootPath, share.Files.First());
+            var directory = _fileSystem.Path.Combine(_fixture.RootPath, _fixture.Directories.First());
+            var filePath = _fileSystem.Path.Combine(_fixture.RootPath, _fixture.Files.First());
             var fileExtension = _fileSystem.Path.GetExtension(filePath);
 
             using var credential = new SMBCredential(credentials.Domain, credentials.Username, credentials.Password, directory, _fixture.SMBCredentialProvider);
@@ -123,10 +130,8 @@ namespace SmbAbstraction.Tests.Integration.FileInfo
         public void CheckFullNameMatches()
         {
             var credentials = _fixture.ShareCredentials;
-            var share = _fixture.Shares.First();
-            var rootPath = share.GetRootPath(_fixture.PathType);
-            var directory = _fileSystem.Path.Combine(rootPath, share.Directories.First());
-            var filePath = _fileSystem.Path.Combine(rootPath, share.Files.First());
+            var directory = _fileSystem.Path.Combine(_fixture.RootPath, _fixture.Directories.First());
+            var filePath = _fileSystem.Path.Combine(_fixture.RootPath, _fixture.Files.First());
 
             using var credential = new SMBCredential(credentials.Domain, credentials.Username, credentials.Password, directory, _fixture.SMBCredentialProvider);
 
@@ -140,9 +145,7 @@ namespace SmbAbstraction.Tests.Integration.FileInfo
         public void CheckReplaceWithBackup()
         {
             var credentials = _fixture.ShareCredentials;
-            var share = _fixture.Shares.First();
-            var rootPath = share.GetRootPath(_fixture.PathType);
-            var directory = _fileSystem.Path.Combine(rootPath, share.Directories.First());
+            var directory = _fileSystem.Path.Combine(_fixture.RootPath, _fixture.Directories.First());
 
             using var credential = new SMBCredential(credentials.Domain, credentials.Username, credentials.Password, directory, _fixture.SMBCredentialProvider);
 
@@ -159,7 +162,7 @@ namespace SmbAbstraction.Tests.Integration.FileInfo
             }
 
             var newFileTime = DateTime.Now.ToFileTimeUtc();
-            var newFilePath = _fileSystem.Path.Combine(rootPath, $"replace-file-{newFileTime}.txt");
+            var newFilePath = _fileSystem.Path.Combine(_fixture.RootPath, $"replace-file-{newFileTime}.txt");
 
             if (!_fileSystem.File.Exists(newFilePath))
             {
@@ -193,9 +196,7 @@ namespace SmbAbstraction.Tests.Integration.FileInfo
         public void CheckReplaceWithoutBackup()
         {
             var credentials = _fixture.ShareCredentials;
-            var share = _fixture.Shares.First();
-            var rootPath = share.GetRootPath(_fixture.PathType);
-            var directory = _fileSystem.Path.Combine(rootPath, share.Directories.First());
+            var directory = _fileSystem.Path.Combine(_fixture.RootPath, _fixture.Directories.First());
 
             using var credential = new SMBCredential(credentials.Domain, credentials.Username, credentials.Password, directory, _fixture.SMBCredentialProvider);
 
@@ -211,7 +212,7 @@ namespace SmbAbstraction.Tests.Integration.FileInfo
             }
 
             var newFileTime = DateTime.Now.ToFileTimeUtc();
-            var newFilePath = _fileSystem.Path.Combine(rootPath, $"replace-file-{newFileTime}.txt");
+            var newFilePath = _fileSystem.Path.Combine(_fixture.RootPath, $"replace-file-{newFileTime}.txt");
 
             if (!_fileSystem.File.Exists(newFilePath))
             {
@@ -223,7 +224,7 @@ namespace SmbAbstraction.Tests.Integration.FileInfo
 
             var newFileInfo = _fileSystem.FileInfo.FromFileName(newFilePath);
 
-            newFileInfo = newFileInfo.Replace(originalFilePath, "");
+            newFileInfo = newFileInfo.Replace(originalFilePath, null);
 
             Assert.Equal(originalFilePath, newFileInfo.FullName);
             Assert.False(_fileSystem.File.Exists(newFilePath));

--- a/SmbAbstraction.Tests.Integration/Fixtures/BaseFileSystemFixture.cs
+++ b/SmbAbstraction.Tests.Integration/Fixtures/BaseFileSystemFixture.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace SmbAbstraction.Tests.Integration.Fixtures
+{
+    public class BaseFileSystemFixture : TestFixture
+    {
+        private readonly IntegrationTestSettings _settings = new IntegrationTestSettings();
+
+        public BaseFileSystemFixture() : base()
+        {
+            _settings.Initialize();
+        }
+
+        public override string LocalTempDirectory
+        {
+            get
+            {
+                if (!string.IsNullOrEmpty(_settings.LocalTempFolder))
+                {
+                    return _settings.LocalTempFolder;
+                }
+
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    System.IO.Directory.CreateDirectory($@"C:\temp\tests");
+                    return $@"C:\temp\tests";
+                }
+                else
+                {
+                    System.IO.Directory.CreateDirectory($@"{Environment.GetEnvironmentVariable("HOME")}/temp/tests");
+                    return $@"{Environment.GetEnvironmentVariable("HOME")}/temp/tests";
+                }
+            }
+        }
+
+        public override ShareCredentials ShareCredentials => _settings.ShareCredentials;
+        public override string ShareName => System.IO.Path.GetPathRoot(RootPath);
+        public override string RootPath => RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? $@"C:\temp" : $@"{Environment.GetEnvironmentVariable("HOME")}/temp";
+
+        public override List<string> Files
+        {
+            get
+            {
+                foreach(var file in _settings.Shares.First().Files)
+                {
+                    var path = System.IO.Path.Combine(RootPath, file);
+                    var fileStream = System.IO.File.Create(path);
+                    fileStream.Close();
+                }
+
+                return _settings.Shares.First().Files;
+            }
+        }
+
+        public override List<string> Directories
+        {
+            get
+            {
+                foreach (var directory in _settings.Shares.First().Directories)
+                {
+                    var path = System.IO.Path.Combine(RootPath, directory);
+                    System.IO.Directory.CreateDirectory(path);
+                }
+
+                return _settings.Shares.First().Directories;
+            }
+        }
+
+        public override PathType PathType => throw new NotImplementedException();
+    }
+}

--- a/SmbAbstraction.Tests.Integration/Fixtures/SmbUriFixture.cs
+++ b/SmbAbstraction.Tests.Integration/Fixtures/SmbUriFixture.cs
@@ -1,13 +1,50 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 
 namespace SmbAbstraction.Tests.Integration.Fixtures
 {
     public class SmbUriFixture : TestFixture
     {
+
+        private readonly IntegrationTestSettings _settings = new IntegrationTestSettings();
+
         public SmbUriFixture() : base()
-        { }
+        {
+            _settings.Initialize();
+        }
+
+
+        public override string LocalTempDirectory
+        {
+            get
+            {
+                if (!string.IsNullOrEmpty(_settings.LocalTempFolder))
+                {
+                    return _settings.LocalTempFolder;
+                }
+
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    return $@"C:\temp";
+                }
+                else
+                {
+                    return $@"{Environment.GetEnvironmentVariable("HOME")}/";
+                }
+            }
+        }
+
+        public override ShareCredentials ShareCredentials => _settings.ShareCredentials;
+
+        public override string ShareName => RootPath.ShareName();
+        public override string RootPath => _settings.Shares.First().GetRootPath(PathType.SmbUri);
+
+        public override List<string> Files => _settings.Shares.First().Files;
+
+        public override List<string> Directories => _settings.Shares.First().Directories;
 
         public override PathType PathType => PathType.SmbUri;
     }

--- a/SmbAbstraction.Tests.Integration/Fixtures/TestFixture.cs
+++ b/SmbAbstraction.Tests.Integration/Fixtures/TestFixture.cs
@@ -7,53 +7,26 @@ namespace SmbAbstraction.Tests.Integration
 {
     public abstract class TestFixture : IDisposable
     {
-        private readonly IntegrationTestSettings _settings = new IntegrationTestSettings();
-
         public TestFixture()
         {
-            _settings.Initialize();
             SMBCredentialProvider = new SMBCredentialProvider();
             SMBClientFactory = new SMB2ClientFactory();
             FileSystem = new SMBFileSystem(SMBClientFactory, SMBCredentialProvider);
         }
 
-        public IntegrationTestSettings TestSettings
-        {
-            get
-            {
-                return _settings;
-            }
-        }
-
         public IFileSystem FileSystem { get; }
 
         public ISMBCredentialProvider SMBCredentialProvider { get; }
-        
+
         public ISMBClientFactory SMBClientFactory { get; }
 
-
-        public string LocalTempDirectory {
-            get
-            {
-                if (!string.IsNullOrEmpty(_settings.LocalTempFolder))
-                {
-                    return _settings.LocalTempFolder;
-                }
-
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                {
-                    return $@"C:\temp";
-                }
-                else
-                {
-                    return $@"{Environment.GetEnvironmentVariable("HOME")}/";
-                }
-            }
-        }
-
-        public ShareCredentials ShareCredentials { get => _settings.ShareCredentials; }
-        public List<Share> Shares { get => _settings.Shares; }
-
+      
+        public abstract string LocalTempDirectory { get; }
+        public abstract ShareCredentials ShareCredentials { get; }
+        public abstract string ShareName { get; }
+        public abstract string RootPath { get; }
+        public abstract List<string> Files { get; }
+        public abstract List<string> Directories { get; }
         public abstract PathType PathType { get; }
 
 

--- a/SmbAbstraction.Tests.Integration/Fixtures/UncPathFixture.cs
+++ b/SmbAbstraction.Tests.Integration/Fixtures/UncPathFixture.cs
@@ -1,13 +1,49 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 
 namespace SmbAbstraction.Tests.Integration.Fixtures
 {
     public class UncPathFixture : TestFixture
     {
+        private readonly IntegrationTestSettings _settings = new IntegrationTestSettings();
+
         public UncPathFixture() : base()
-        { }
+        {
+            _settings.Initialize();
+        }
+
+
+        public override string LocalTempDirectory
+        {
+            get
+            {
+                if (!string.IsNullOrEmpty(_settings.LocalTempFolder))
+                {
+                    return _settings.LocalTempFolder;
+                }
+
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    return $@"C:\temp";
+                }
+                else
+                {
+                    return $@"{Environment.GetEnvironmentVariable("HOME")}/";
+                }
+            }
+        }
+
+        public override ShareCredentials ShareCredentials => _settings.ShareCredentials;
+
+        public override string ShareName => RootPath.ShareName(); 
+        public override string RootPath => _settings.Shares.First().GetRootPath(PathType.UncPath);
+
+        public override List<string> Files => _settings.Shares.First().Files;
+
+        public override List<string> Directories => _settings.Shares.First().Directories;
 
         public override PathType PathType => PathType.UncPath;
     }

--- a/SmbAbstraction.Tests.Integration/IntegrationTestSettings.cs
+++ b/SmbAbstraction.Tests.Integration/IntegrationTestSettings.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.Configuration;
 using System;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using System.Text;
 
 namespace SmbAbstraction.Tests.Integration
@@ -36,8 +37,9 @@ namespace SmbAbstraction.Tests.Integration
                 case PathType.SmbUri:
                     return $@"smb://{HostName}/{ShareName}";
                 case PathType.UncPath:
-                default:
                     return $@"\\{HostName}\{ShareName}";
+                default:
+                    throw new ArgumentException($"PathType must be SmbUri or UncPath");
             }
         }
     }

--- a/SmbAbstraction.Tests.Integration/Stream/StreamTests.Variations.cs
+++ b/SmbAbstraction.Tests.Integration/Stream/StreamTests.Variations.cs
@@ -15,4 +15,9 @@ namespace SmbAbstraction.Tests.Integration.Stream
     {
         public SmbUriTests(SmbUriFixture fixture) : base(fixture) { }
     }
+
+    public class BaseFileSystemTests : StreamTests, IClassFixture<BaseFileSystemFixture>
+    {
+        public BaseFileSystemTests(BaseFileSystemFixture fixture) : base(fixture) { }
+    }
 }

--- a/SmbAbstraction.Tests.Integration/Stream/StreamTests.cs
+++ b/SmbAbstraction.Tests.Integration/Stream/StreamTests.cs
@@ -22,9 +22,7 @@ namespace SmbAbstraction.Tests.Integration.Stream
         {
             var tempFileName = $"temp-CheckStreamLength-{DateTime.Now.ToFileTimeUtc()}.txt";
             var credentials = _fixture.ShareCredentials;
-            var share = _fixture.Shares.First();
-            var rootPath = share.GetRootPath(_fixture.PathType);
-            var directory = _fileSystem.Path.Combine(rootPath, share.Directories.First());
+            var directory = _fileSystem.Path.Combine(_fixture.RootPath, _fixture.Directories.First());
             var tempFilePath = _fileSystem.Path.Combine(_fixture.LocalTempDirectory, tempFileName);
 
             var byteArray = new byte[100];

--- a/SmbAbstraction/Directory/SMBDirectoryInfoFactory.cs
+++ b/SmbAbstraction/Directory/SMBDirectoryInfoFactory.cs
@@ -33,7 +33,7 @@ namespace SmbAbstraction
             if (!directoryName.IsSharePath())
             {
                 var dirInfo = new DirectoryInfo(directoryName);
-                return new SMBDirectoryInfo(dirInfo, _smbDirectory, _smbFile, this, _fileInfoFactory, _fileSystem, _credentialProvider);
+                return new SMBDirectoryInfo(dirInfo, _fileSystem, _credentialProvider);
             }
 
             return FromDirectoryName(directoryName, null);
@@ -84,7 +84,7 @@ namespace SmbAbstraction
                 return null;
             }
 
-            return new SMBDirectoryInfo(path, _smbDirectory, _smbFile, this, _fileInfoFactory, fileInfo, _fileSystem, _credentialProvider, credential);
+            return new SMBDirectoryInfo(path, fileInfo,_fileSystem, _credentialProvider, credential);
         }
 
         internal void SaveDirectoryInfo(SMBDirectoryInfo dirInfo, ISMBCredential credential = null)

--- a/SmbAbstraction/Extensions/PathExtensions.cs
+++ b/SmbAbstraction/Extensions/PathExtensions.cs
@@ -144,7 +144,7 @@ namespace SmbAbstraction
             var pathUri = new Uri(path);
             var parentUri = pathUri.AbsoluteUri.EndsWith('/') ? new Uri(pathUri, "..") : new Uri(pathUri, ".");
             var pathString = parentUri.IsUnc ? parentUri.LocalPath : parentUri.AbsoluteUri;
-            return pathString;
+            return pathString.RemoveTrailingSeperators();
         }
 
         public static string GetLastPathSegment(this string path)
@@ -179,6 +179,19 @@ namespace SmbAbstraction
                 if (input.StartsWith(pathSeperator))
                 {
                     input = input.Remove(0, 1);
+                }
+            }
+
+            return input;
+        }
+
+        private static string RemoveTrailingSeperators(this string input)
+        {
+            foreach (var pathSeperator in pathSeperators)
+            {
+                if (input.EndsWith(pathSeperator))
+                {
+                    input = input.Remove(input.LastIndexOf(pathSeperator), 1);
                 }
             }
 

--- a/SmbAbstraction/File/SMBFileInfo.cs
+++ b/SmbAbstraction/File/SMBFileInfo.cs
@@ -31,7 +31,7 @@ namespace SmbAbstraction
             _lastWriteTime = fileInfo.LastWriteTime;
             _lastWriteTimeUtc = fileInfo.LastWriteTimeUtc;
             _attributes = fileInfo.Attributes;
-            _directory = new DirectoryInfoWrapper(fileSystem, fileInfo.Directory);
+            _directory = _dirInfoFactory.FromDirectoryName(fileInfo.Directory.FullName);
             _directoryName = fileInfo.DirectoryName;
             _exists = fileInfo.Exists;
             _isReadOnly = fileInfo.IsReadOnly;
@@ -271,6 +271,13 @@ namespace SmbAbstraction
             if (string.IsNullOrEmpty(destinationFilePath))
             {
                 throw new ArgumentNullException(nameof(destinationFilePath));
+            }
+
+            if(destinationBackupFilePath == string.Empty)
+            {
+                ///https://docs.microsoft.com/en-us/dotnet/api/system.io.fileinfo.replace?view=netcore-3.1
+                throw new ArgumentNullException(nameof(destinationBackupFilePath), 
+                                                $"Destination backup path cannot be empty. Pass null if you do not want to create backup of file being replaced.");
             }
 
             var path = FullName;

--- a/SmbAbstraction/FileSystem/SMBFileSystemInformation.cs
+++ b/SmbAbstraction/FileSystem/SMBFileSystemInformation.cs
@@ -15,12 +15,10 @@ namespace SmbAbstraction
         public FileFsControlInformation ControlInformation { get; }
         public FileFsSectorSizeInformation SectorSizeInformation { get; }
 
-        public SMBFileSystemInformation(ISMBFileStore fileStore, string path)
+        public SMBFileSystemInformation(ISMBFileStore fileStore, string path, NTStatus status)
         {
             var shareName = path.ShareName();
             var relativePath = path.RelativeSharePath();
-
-            NTStatus status = NTStatus.STATUS_SUCCESS;
 
             if (status == NTStatus.STATUS_SUCCESS)
             {

--- a/SmbAbstraction/Path/SMBPath.cs
+++ b/SmbAbstraction/Path/SMBPath.cs
@@ -178,7 +178,13 @@ namespace SmbAbstraction
 
         public override string GetPathRoot(string path)
         {
-            return base.GetPathRoot(path);
+            if (!path.IsSharePath())
+            {
+                return base.GetPathRoot(path);
+            }
+            
+            var pathRoot = path.SharePath();
+            return pathRoot;               
         }
 
         public override string GetRandomFileName()


### PR DESCRIPTION
### Changes

- Add `BaseFileSystem`  test Fixture.
- Update `TestFixture` base class to better support testing of base filesystem and smbfilesystem 
- Fix `Object Null Reference` when creating `SMBDirectoryInfo` with non share file path, by properly terminating the recursive call for `_parent` as per the `System.IO.DirectoryInfo` spec.
- Update directory object for `SMBFileInfo(FileInfo,IFileSystem) to call SMBDirectoryInfoFactory.FromDirectoryName` 
- Remove trailing path on `PathExtenstions.GetParentPath` which was causing an extra call in `SMBDirectoryInfo(string, FileInformation, IFileSystem, ISMBCredentialProvider, ISMBCredential)`.
- Properly determine and terminate `_root` in `SMBDirectoryInfo` when initializing by `SMBDirectoryInfo(string, FileInformation, IFileSystem, ISMBCredentialProvider, ISMBCredential)`
- Add `NTStatus` parameter in `SMBFileSystemInformation` constructor so that the conditional is actually utilized.
- Add share path implementation for `SMBPath.GetPathRoot()`
- Clean `SMBDirectoryInfo` constructor parameters so that it matches `SMBFileInfo`
