### PR TITLE
Unescape Uri strings that cause `STATUS_ACCESS_DENIED` and `STATUS_NOT_FOUND` due to Uri escape symbols being part of the literall string

### DIFF
--- a/SmbAbstraction.Tests/Path/PathTestData.cs
+++ b/SmbAbstraction.Tests/Path/PathTestData.cs
@@ -14,17 +14,27 @@
     {
         public string Root { get { return "smb://host/share"; } }
         public string DirectoryAtRoot { get { return "smb://host/share/dir"; } }
+        public string SpaceInDirectoryAtRoot { get { return "smb://host/share/dir dir/file.txt"; } }
         public string FileAtRoot { get { return "smb://host/share/file.txt"; } }
+        public string SpaceInFileAtRoot { get { return "smb://host/share/text file.txt"; } }
         public string NestedDirectoryAtRoot {  get { return "smb://host/share/dir/nested_dir"; } }
         public string FileInNestedDirectoryAtRoot { get { return "smb://host/share/dir/nested_dir/file.txt"; } }
+        public string SpaceInFileInNestedDirectoryAtRoot { get { return "smb://host/share/dir/nested_dir/text file.txt"; } }
+        public string SpaceInFileAndInNestedDirectoryAtRoot { get { return "smb://host/share/dir/nested dir/text file.txt"; } }
+
     }
 
     public class UncPathTestData : IPathTestData
     {
         public string Root { get { return $@"\\host\share"; } }
         public string DirectoryAtRoot { get { return $@"\\host\share\dir"; } }
+        public string SpaceInDirectoryAtRoot { get { return @"\\host\share\dir dir\file.txt"; } }
         public string FileAtRoot { get { return $@"\\host\share\file.txt"; } }
+        public string SpaceInFileAtRoot { get { return @"\\host\share\text file.txt"; } }
         public string NestedDirectoryAtRoot { get { return $@"\\host\share\dir\nested_dir"; } }
+        public string SpaceInNestedDirectoryAtRoot { get { return $@"\\host\share\dir\nested dir"; } }
         public string FileInNestedDirectoryAtRoot { get { return $@"\\host\share\dir\nested_dir\file.text"; } }
+        public string SpaceInFileInNestedDirectoryAtRoot { get { return $@"\\host\share\dir\nested_dir\text file.text"; } }
+        public string SpaceInFileAndInNestedDirectoryAtRoot { get { return $@"\\host\share\dir\nested dir\text file.text"; } }
     }
 }

--- a/SmbAbstraction/Extensions/PathExtensions.cs
+++ b/SmbAbstraction/Extensions/PathExtensions.cs
@@ -143,14 +143,14 @@ namespace SmbAbstraction
         {
             var pathUri = new Uri(path);
             var parentUri = pathUri.AbsoluteUri.EndsWith('/') ? new Uri(pathUri, "..") : new Uri(pathUri, ".");
-            var pathString = parentUri.IsUnc ? parentUri.LocalPath : parentUri.AbsoluteUri;
+            var pathString = parentUri.IsUnc ? parentUri.LocalPath : Uri.UnescapeDataString(parentUri.AbsoluteUri);
             return pathString.RemoveTrailingSeperators();
         }
 
         public static string GetLastPathSegment(this string path)
         {
             var uri = new Uri(path);
-            return uri.Segments.Last().Replace("%20", " ");
+            return Uri.UnescapeDataString(uri.Segments.Last());
         }
 
         public static string RemoveAnySeperators(this string input)

--- a/SmbAbstraction/File/SMBFileInfo.cs
+++ b/SmbAbstraction/File/SMBFileInfo.cs
@@ -62,11 +62,10 @@ namespace SmbAbstraction
 
             _attributes = (System.IO.FileAttributes)fileBasicInformation.FileAttributes;
 
-            var pathUri = new Uri(path);
-            var parentUri = pathUri.AbsoluteUri.EndsWith('/') ? new Uri(pathUri, "..") : new Uri(pathUri, ".");
-            var parentPathString = parentUri.IsUnc ? parentUri.LocalPath : parentUri.AbsoluteUri;
+            var parentPath = _fileSystem.Path.Combine(path.SharePath(), _fileSystem.Path.GetDirectoryName(path));
+            
 
-            _directory = _dirInfoFactory.FromDirectoryName(parentPathString, credential);
+            _directory = _dirInfoFactory.FromDirectoryName(parentPath, credential);
             _directoryName = Directory?.Name;
             _exists = _file.Exists(path);
             _isReadOnly = fileBasicInformation.FileAttributes.HasFlag(SMBLibrary.FileAttributes.ReadOnly);

--- a/SmbAbstraction/Path/SMBPath.cs
+++ b/SmbAbstraction/Path/SMBPath.cs
@@ -120,7 +120,15 @@ namespace SmbAbstraction
             var segments = relativePath.Split(@"\");
             if (HasExtension(segments.Last()))
             {
-                directoryName = string.Join('\\',segments.Take(segments.Length - 1));
+                if(path.IsSmbUri())
+                {
+                    directoryName = string.Join('/', segments.Take(segments.Length - 1));
+                }
+
+                if (path.IsUncPath())
+                {
+                    directoryName = string.Join('\\', segments.Take(segments.Length - 1));
+                }
             }
             else
             {


### PR DESCRIPTION
Unescape Uri strings that cause `STATUS_ACCESS_DENIED` and `STATUS_NOT_FOUND` due to  Uri escape symbols (ie. `%20`) being part of the literal string.