### PR TITLE
Fix SMBPath.GetDirectoryName()

### DIFF
--- a/SmbAbstraction/Directory/SMBDirectory.cs
+++ b/SmbAbstraction/Directory/SMBDirectory.cs
@@ -499,7 +499,7 @@ namespace SmbAbstraction
                             }
                             else
                             {
-                                files.Add(_fileSystem.Path.Combine(path, fileDirectoryInformation.FileName.RemoveAnySeperators()));
+                                files.Add(_fileSystem.Path.Combine(path, fileDirectoryInformation.FileName.RemoveLeadingAndTrailingSeperators()));
                             }
                         }
                     }
@@ -653,7 +653,7 @@ namespace SmbAbstraction
 
                     var parentFullPath = path.GetParentPath();
                     var parentPath = parentFullPath.RelativeSharePath();
-                    var directoryName = path.GetLastPathSegment().RemoveAnySeperators();
+                    var directoryName = path.GetLastPathSegment().RemoveLeadingAndTrailingSeperators();
 
                     ISMBFileStore fileStore = connection.SMBClient.TreeConnect(shareName, out status);
 

--- a/SmbAbstraction/Directory/SMBDirectoryInfo.cs
+++ b/SmbAbstraction/Directory/SMBDirectoryInfo.cs
@@ -82,7 +82,7 @@ namespace SmbAbstraction
 
             _exists = _fileSystem.Directory.Exists(FullName);
             _extension = string.Empty;
-            _name = _fullName.GetLastPathSegment().RemoveAnySeperators();
+            _name = _fullName.GetLastPathSegment().RemoveLeadingAndTrailingSeperators();
         }
 
         private IDirectoryInfo _root;

--- a/SmbAbstraction/Extensions/PathExtensions.cs
+++ b/SmbAbstraction/Extensions/PathExtensions.cs
@@ -153,7 +153,38 @@ namespace SmbAbstraction
             return Uri.UnescapeDataString(uri.Segments.Last());
         }
 
-        public static string RemoveAnySeperators(this string input)
+        public static string RemoveLeadingAndTrailingSeperators(this string input)
+        {
+            return input.RemoveLeadingSeperators().RemoveLeadingSeperators();
+        }
+
+        public static string RemoveLeadingSeperators(this string input)
+        {
+            foreach (var pathSeperator in pathSeperators)
+            {
+                if (input.StartsWith(pathSeperator))
+                {
+                    input = input.Remove(0, 1);
+                }
+            }
+
+            return input;
+        }
+
+        public static string RemoveTrailingSeperators(this string input)
+        {
+            foreach (var pathSeperator in pathSeperators)
+            {
+                if (input.EndsWith(pathSeperator))
+                {
+                    input = input.Remove(input.LastIndexOf(pathSeperator), 1);
+                }
+            }
+
+            return input;
+        }
+
+        private static string RemoveAnySeperators(this string input)
         {
             foreach (var pathSeperator in pathSeperators)
             {
@@ -168,32 +199,6 @@ namespace SmbAbstraction
             var sharePath = input.SharePath();
 
             input = input.Replace(sharePath, "", StringComparison.InvariantCultureIgnoreCase);
-
-            return input;
-        }
-
-        private static string RemoveLeadingSeperators(this string input)
-        {
-            foreach (var pathSeperator in pathSeperators)
-            {
-                if (input.StartsWith(pathSeperator))
-                {
-                    input = input.Remove(0, 1);
-                }
-            }
-
-            return input;
-        }
-
-        private static string RemoveTrailingSeperators(this string input)
-        {
-            foreach (var pathSeperator in pathSeperators)
-            {
-                if (input.EndsWith(pathSeperator))
-                {
-                    input = input.Remove(input.LastIndexOf(pathSeperator), 1);
-                }
-            }
 
             return input;
         }

--- a/SmbAbstraction/File/SMBFile.cs
+++ b/SmbAbstraction/File/SMBFile.cs
@@ -304,7 +304,7 @@ namespace SmbAbstraction
                 using (var connection = SMBConnection.CreateSMBConnection(_smbClientFactory, ipAddress, transport, credential, _maxBufferSize))
                 {
                     var shareName = path.ShareName();
-                    var directoryPath = _fileSystem.Path.GetDirectoryName(path);
+                    var directoryPath = _fileSystem.Path.GetDirectoryName(path).Replace(path.SharePath(), "").RemoveLeadingAndTrailingSeperators();
                     var fileName = _fileSystem.Path.GetFileName(path);
 
                     _logger?.LogTrace($"Trying to determine if {{DirectoryPath: {directoryPath}}} {{FileName: {fileName}}} Exists for {{ShareName: {shareName}}}");

--- a/SmbAbstraction/File/SMBFileInfo.cs
+++ b/SmbAbstraction/File/SMBFileInfo.cs
@@ -62,7 +62,7 @@ namespace SmbAbstraction
 
             _attributes = (System.IO.FileAttributes)fileBasicInformation.FileAttributes;
 
-            var parentPath = _fileSystem.Path.Combine(path.SharePath(), _fileSystem.Path.GetDirectoryName(path));
+            var parentPath = _fileSystem.Path.GetDirectoryName(path);
             
 
             _directory = _dirInfoFactory.FromDirectoryName(parentPath, credential);

--- a/SmbAbstraction/Path/SMBPath.cs
+++ b/SmbAbstraction/Path/SMBPath.cs
@@ -122,12 +122,12 @@ namespace SmbAbstraction
             {
                 if(path.IsSmbUri())
                 {
-                    directoryName = string.Join('/', segments.Take(segments.Length - 1));
+                    directoryName = Combine(path.SharePath(),string.Join('/', segments.Take(segments.Length - 1)));
                 }
 
                 if (path.IsUncPath())
                 {
-                    directoryName = string.Join('\\', segments.Take(segments.Length - 1));
+                    directoryName = Combine(path.SharePath(), string.Join('\\', segments.Take(segments.Length - 1)));
                 }
             }
             else


### PR DESCRIPTION
Fix implementaion of SMBPath.GetDirectoryName()

Add RemoveLeadingAndTrailingSeperators() to PathExtensions.

Make RemoveAnySeperators() private

Replace calls to RemoveAnySeperators() to RemoveLeadingAndTrailingSeperators()

Fix call to SMBPath.GetDirectoryName in SMBFileInfo