### PR TITLE
Apply `AccessMask.SYNCHRONIZE` and `CreateOptions.FILE_SYNCHRONOUS_IO_NONALERT` to all `fileStore.CreateFile` calls to ensure synchrony on operations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project tries to adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.7] - 2020-04-30
+
+### Changed
+- Apply `AccessMask.SYNCHRONIZE` and `CreateOptions.FILE_SYNCHRONOUS_IO_NONALERT` to all `fileStore.CreateFile` calls to ensure synchrony on operations.
+	- Left retry logic in place for now, `STATUS_PENDING` seems to no longer occur
+- Set explicit `ShareAccess.Read`  and `ShareAccess.Write` to `fileStore.CreateFile` calls for better Samba compabitility.
+	- Windows Share ACL was fine with how we were defining `ShareAccess` on calls. Samba shares seem to be picky about it.
+- Remove calls to `ToUniversalTime()`  from `Set*Time` in SMBFile
+- Add tests in `FileTests` for `IFile.Open` operations  
+### Fixed 
+- Fix `Set*TimeUtc` calls to use `ToUniversalTime()`  in SMBFile
+- Match `DirectoryName` behavior in `SMBFIleInfo` with `base.FileInfo`
+
 ## [1.1.6] - 2020-04-26
 
 ### Fixed

--- a/SmbAbstraction.Tests.Integration/File/FileTests.cs
+++ b/SmbAbstraction.Tests.Integration/File/FileTests.cs
@@ -49,6 +49,31 @@ namespace SmbAbstraction.Tests.Integration.File
 
         [Fact]
         [Trait("Category", "Integration")]
+        public void TestExistsForExistingFile()
+        {
+            var credentials = _fixture.ShareCredentials;
+            var filePath = _fileSystem.Path.Combine(_fixture.RootPath, _fixture.Files.First());
+
+            using var credential = new SMBCredential(credentials.Domain, credentials.Username, credentials.Password, _fixture.RootPath, _fixture.SMBCredentialProvider);
+
+            Assert.True(_fileSystem.File.Exists(filePath));
+        }
+
+        [Fact]
+        [Trait("Category", "Integration")]
+        public void TestExistsForNonExistingFile()
+        {
+            var tempFileName = $"temp-{DateTime.Now.ToFileTimeUtc()}.txt";
+            var credentials = _fixture.ShareCredentials;
+            var tempFilePath = _fileSystem.Path.Combine(_fixture.RootPath, tempFileName);
+
+            using var credential = new SMBCredential(credentials.Domain, credentials.Username, credentials.Password, _fixture.RootPath, _fixture.SMBCredentialProvider);
+
+            Assert.False(_fileSystem.File.Exists(tempFilePath));
+        }
+
+        [Fact]
+        [Trait("Category", "Integration")]
         public void TestMove()
         {
             var tempFileName = $"temp-{DateTime.Now.ToFileTimeUtc()}.txt";
@@ -128,6 +153,119 @@ namespace SmbAbstraction.Tests.Integration.File
 
             Assert.True(_fileSystem.File.Exists(moveToFilePath));
             Assert.False(_fileSystem.File.Exists(tempFilePath));
+
+            _fileSystem.File.Delete(moveToFilePath);
+        }
+
+        [Fact]
+        [Trait("Category", "Integration")]
+        public void TestCreateFile()
+        {
+            var tempFileName = $"temp-{DateTime.Now.ToFileTimeUtc()}.txt";
+            var credentials = _fixture.ShareCredentials;
+            var directory = _fileSystem.Path.Combine(_fixture.RootPath, _fixture.Directories.First());
+            var tempFilePath = _fileSystem.Path.Combine(_fixture.RootPath, tempFileName);
+
+            using var credential = new SMBCredential(credentials.Domain, credentials.Username, credentials.Password, directory, _fixture.SMBCredentialProvider);
+
+            using var fileStream = _fileSystem.File.Create(tempFilePath);
+            fileStream.Close();
+
+            _fileSystem.File.Delete(tempFilePath);
+        }
+
+        [Fact]
+        [Trait("Category", "Integration")]
+        public void TestFileOpenOnExistingFile()
+        {
+            var credentials = _fixture.ShareCredentials;
+            var filePath = _fileSystem.Path.Combine(_fixture.RootPath, _fixture.Files.First());
+
+            using var credential = new SMBCredential(credentials.Domain, credentials.Username, credentials.Password, _fixture.RootPath, _fixture.SMBCredentialProvider);
+
+            using var fileStream = _fileSystem.File.Open(filePath, FileMode.Open);
+            fileStream.Close();
+        }
+
+        [Fact]
+        [Trait("Category", "Integration")]
+        public void TestFileOpenOnCreatedFile()
+        {
+            var tempFileName = $"temp-{DateTime.Now.ToFileTimeUtc()}.txt";
+            var credentials = _fixture.ShareCredentials;
+            var directory = _fileSystem.Path.Combine(_fixture.RootPath, _fixture.Directories.First());
+            var tempFilePath = _fileSystem.Path.Combine(_fixture.RootPath, tempFileName);
+
+            using var credential = new SMBCredential(credentials.Domain, credentials.Username, credentials.Password, directory, _fixture.SMBCredentialProvider);
+
+            if (!_fileSystem.File.Exists(tempFilePath))
+            {
+                using (var streamWriter = new StreamWriter(_fileSystem.File.Create(tempFilePath)))
+                {
+                    streamWriter.WriteLine("Test");
+                }
+            }
+
+            using var fileStream = _fileSystem.File.Open(tempFilePath, FileMode.Open);
+            fileStream.Close();
+
+            _fileSystem.File.Delete(tempFilePath);
+        }
+
+        [Fact]
+        [Trait("Category", "Integration")]
+        public void TestFileOpen_FileModeCreate()
+        {
+            var tempFileName = $"temp-{DateTime.Now.ToFileTimeUtc()}.txt";
+            var credentials = _fixture.ShareCredentials;
+            var directory = _fileSystem.Path.Combine(_fixture.RootPath, _fixture.Directories.First());
+            var tempFilePath = _fileSystem.Path.Combine(_fixture.RootPath, tempFileName);
+
+            using var credential = new SMBCredential(credentials.Domain, credentials.Username, credentials.Password, directory, _fixture.SMBCredentialProvider);
+
+            using var fileStream = _fileSystem.File.Open(tempFilePath, FileMode.Create);
+            fileStream.Close();
+
+            _fileSystem.File.Delete(tempFilePath);
+        }
+
+        [Fact]
+        [Trait("Category", "Integration")]
+        public void TestFileOpen_FileModeOpenOrCreate()
+        {
+            var tempFileName = $"temp-{DateTime.Now.ToFileTimeUtc()}.txt";
+            var credentials = _fixture.ShareCredentials;
+            var directory = _fileSystem.Path.Combine(_fixture.RootPath, _fixture.Directories.First());
+            var tempFilePath = _fileSystem.Path.Combine(_fixture.RootPath, tempFileName);
+
+            using var credential = new SMBCredential(credentials.Domain, credentials.Username, credentials.Password, directory, _fixture.SMBCredentialProvider);
+
+            using var fileStream = _fileSystem.File.Open(tempFilePath, FileMode.OpenOrCreate);
+            fileStream.Close();
+
+            _fileSystem.File.Delete(tempFilePath);
+        }
+
+        [Fact]
+        [Trait("Category", "Integration")]
+        public void CanSetCreationTime()
+        {
+            var tempFileName = $"temp-{DateTime.Now.ToFileTimeUtc()}.txt";
+            var credentials = _fixture.ShareCredentials;
+            var tempFilePath = _fileSystem.Path.Combine(_fixture.RootPath, tempFileName);
+
+            using var credential = new SMBCredential(credentials.Domain, credentials.Username, credentials.Password, _fixture.RootPath, _fixture.SMBCredentialProvider);
+
+            if (!_fileSystem.File.Exists(tempFilePath))
+            {
+                using (var stream = _fileSystem.File.Create(tempFilePath))
+                {
+                }
+            }
+
+            _fileSystem.File.SetCreationTime(tempFilePath, DateTime.Now.AddMinutes(10));
+
+            _fileSystem.File.Delete(tempFilePath);
         }
     }
 }

--- a/SmbAbstraction/File/SMBFileInfo.cs
+++ b/SmbAbstraction/File/SMBFileInfo.cs
@@ -66,7 +66,7 @@ namespace SmbAbstraction
             
 
             _directory = _dirInfoFactory.FromDirectoryName(parentPath, credential);
-            _directoryName = Directory?.Name;
+            _directoryName = parentPath;
             _exists = _file.Exists(path);
             _isReadOnly = fileBasicInformation.FileAttributes.HasFlag(SMBLibrary.FileAttributes.ReadOnly);
             _length = fileStandardInformation.EndOfFile;
@@ -91,14 +91,14 @@ namespace SmbAbstraction
         public override bool IsReadOnly { get => _isReadOnly; }
         public override long Length { get => _length; }
         public override System.IO.FileAttributes Attributes { get => _attributes; }
-        public override DateTime CreationTime { get => _creationTime; }
-        public override DateTime CreationTimeUtc { get => _creationTimeUtc; }
+        public override DateTime CreationTime { get => _creationTime; set => _creationTime = value; }
+        public override DateTime CreationTimeUtc { get => _creationTimeUtc; set => _creationTimeUtc = value; }
         public override bool Exists { get => _exists; }
         public override string FullName { get => _fullName; }
-        public override DateTime LastAccessTime { get => _lastAccessTime; }
-        public override DateTime LastAccessTimeUtc { get => _lastAccessTimeUtc; }
-        public override DateTime LastWriteTime { get => _lastWriteTime; }
-        public override DateTime LastWriteTimeUtc { get => _lastWriteTimeUtc; }
+        public override DateTime LastAccessTime { get => _lastAccessTime; set => _lastAccessTime = value; }
+        public override DateTime LastAccessTimeUtc { get => _lastAccessTimeUtc; set => _lastAccessTimeUtc = value; }
+        public override DateTime LastWriteTime { get => _lastWriteTime; set => _lastWriteTime = value; }
+        public override DateTime LastWriteTimeUtc { get => _lastWriteTimeUtc; set => _lastWriteTimeUtc = value; }
 
         public override StreamWriter AppendText()
         {

--- a/SmbAbstraction/File/SMBFileInfoFactory.cs
+++ b/SmbAbstraction/File/SMBFileInfoFactory.cs
@@ -77,8 +77,13 @@ namespace SmbAbstraction
 
                 status.HandleStatus();
 
-                status = fileStore.CreateFile(out object handle, out FileStatus fileStatus, relativePath, AccessMask.GENERIC_READ, 0, ShareAccess.Read,
-                        CreateDisposition.FILE_OPEN, CreateOptions.FILE_NON_DIRECTORY_FILE, null);
+                AccessMask accessMask = AccessMask.SYNCHRONIZE | AccessMask.GENERIC_READ;
+                ShareAccess shareAccess = ShareAccess.Read;
+                CreateDisposition disposition = CreateDisposition.FILE_OPEN;
+                CreateOptions createOptions = CreateOptions.FILE_SYNCHRONOUS_IO_NONALERT | CreateOptions.FILE_NON_DIRECTORY_FILE;
+
+                status = fileStore.CreateFile(out object handle, out FileStatus fileStatus, relativePath, accessMask, 0, shareAccess,
+                    disposition, createOptions, null);
 
                 status.HandleStatus();
 
@@ -129,8 +134,15 @@ namespace SmbAbstraction
 
                 ISMBFileStore fileStore = connection.SMBClient.TreeConnect(shareName, out status);
 
-                status = fileStore.CreateFile(out object handle, out FileStatus fileStatus, relativePath, AccessMask.GENERIC_WRITE, 0, ShareAccess.Read,
-                        CreateDisposition.FILE_OPEN, CreateOptions.FILE_NON_DIRECTORY_FILE, null);
+                status.HandleStatus();
+
+                AccessMask accessMask = AccessMask.SYNCHRONIZE | AccessMask.GENERIC_WRITE;
+                ShareAccess shareAccess = ShareAccess.Read;
+                CreateDisposition disposition = CreateDisposition.FILE_OPEN;
+                CreateOptions createOptions = CreateOptions.FILE_SYNCHRONOUS_IO_NONALERT | CreateOptions.FILE_NON_DIRECTORY_FILE;
+
+                status = fileStore.CreateFile(out object handle, out FileStatus fileStatus, relativePath, accessMask, 0, shareAccess,
+                    disposition, createOptions, null);
 
                 status.HandleStatus();
 

--- a/SmbAbstraction/SmbAbstraction.csproj
+++ b/SmbAbstraction/SmbAbstraction.csproj
@@ -12,7 +12,7 @@
     <PackageId>SmbAbstraction</PackageId>
     <RepositoryUrl>https://github.com/jordanlytle/SmbAbstraction</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <PackageVersion>1.1.6</PackageVersion>
+    <PackageVersion>1.1.7</PackageVersion>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -20,7 +20,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <Version>1.1.6</Version>
+    <Version>1.1.7</Version>
   </PropertyGroup>
   
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
### Changed
- Apply `AccessMask.SYNCHRONIZE` and `CreateOptions.FILE_SYNCHRONOUS_IO_NONALERT` to all `fileStore.CreateFile` calls to ensure synchrony on operations.
	- Left retry logic in place for now, `STATUS_PENDING` seems to no longer occur
- Set explicit `ShareAccess.Read`  and `ShareAccess.Write` to `fileStore.CreateFile` calls for better Samba compabitility.
	- Windows Share ACL was fine with how we were defining `ShareAccess` on calls. Samba shares seem to be picky about it.
- Remove calls to `ToUniversalTime()`  from `Set*Time` in SMBFile
- Add tests in `FileTests` for `IFile.Open` operations  
### Fixed 
- Fix `Set*TimeUtc` calls to use `ToUniversalTime()`  in SMBFile
- Match `DirectoryName` behavior in `SMBFIleInfo` with `base.FileInfo`