### PR TITLE
[1.1.10-alpha-01] `PathExtensions.RemoveLeadingAndTrailingSeparators()` was calling `RemoveLeadingSeparators` twice and not calling `RemoveTrailingSeparators`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project tries to adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.10-alpha-01] 2020-05-15
+
+### Changed
+- Close any potential `fileStore` and `handles` in `SMBDirectory.Exists` and `SMBFile.Exists` when an exception is caught before returning false
+- Added `SMBDirectory` and `SMBDirectoryInfo` tests that check if operations succeed with trailing separators
+
+### Fixed
+- `PathExtensions.RemoveLeadingAndTrailingSeparators()` was calling `RemoveLeadingSeparators` twice and not calling `RemoveTrailingSeparators`
+
+
+## [1.1.10-alpha] 2020-05-12
+
+### Changed
+- Update SMBLibraryLite to 1.4.3-alpha
+	- Temporaily Fixes "Not enough credits" exception when reading large files
+
+
 ## [1.1.9] - 2020-05-07
 
 ### Changed

--- a/SmbAbstraction.Tests.Integration/Directory/DirectoryTests.cs
+++ b/SmbAbstraction.Tests.Integration/Directory/DirectoryTests.cs
@@ -43,6 +43,22 @@ namespace SmbAbstraction.Tests.Integration.Directory
 
         [Fact]
         [Trait("Category", "Integration")]
+        public void CanCreateDirectoryInRootDirectory_WithTrailingSeparator()
+        {
+            var credentials = _fixture.ShareCredentials;
+
+            createdTestDirectoryPath = _fileSystem.Path.Combine(_fixture.RootPath, $"test_directory-{DateTime.Now.ToFileTimeUtc()}") + $"{(_fixture.PathType == PathType.SmbUri ? '/' : '\\')}";
+
+            using var credential = new SMBCredential(credentials.Domain, credentials.Username, credentials.Password, createdTestDirectoryPath, _fixture.SMBCredentialProvider);
+
+            var directoryInfo = _fileSystem.Directory.CreateDirectory(createdTestDirectoryPath);
+
+            Assert.True(_fileSystem.Directory.Exists(createdTestDirectoryPath));
+        }
+
+
+        [Fact]
+        [Trait("Category", "Integration")]
         public void CheckCreateDirectoryForExistingDirectory()
         {
             var credentials = _fixture.ShareCredentials;
@@ -60,12 +76,48 @@ namespace SmbAbstraction.Tests.Integration.Directory
 
         [Fact]
         [Trait("Category", "Integration")]
+        public void CheckCreateDirectoryForExistingDirectory_WithTrailingSeparator()
+        {
+            var credentials = _fixture.ShareCredentials;
+
+            var existingDirectory = _fileSystem.Path.Combine(_fixture.RootPath, _fixture.Directories.First()) + $"{(_fixture.PathType == PathType.SmbUri ? '/' : '\\')}";
+
+            using var credential = new SMBCredential(credentials.Domain, credentials.Username, credentials.Password, existingDirectory, _fixture.SMBCredentialProvider);
+
+            var existingDirectoryInfo = _fileSystem.DirectoryInfo.FromDirectoryName(existingDirectory);
+
+            var directoryInfo = _fileSystem.Directory.CreateDirectory(existingDirectory);
+
+            Assert.Equal(existingDirectoryInfo.FullName, directoryInfo.FullName);
+        }
+
+
+        [Fact]
+        [Trait("Category", "Integration")]
         public void CanCreateNestedDirectoryInRootDirectory()
         {
             var credentials = _fixture.ShareCredentials;
 
             var parentDirectoryPath = _fileSystem.Path.Combine(_fixture.RootPath, $"test_directory_parent-{DateTime.Now.ToFileTimeUtc()}");
             createdTestDirectoryPath = _fileSystem.Path.Combine(parentDirectoryPath, $"test_directory_child-{DateTime.Now.ToFileTimeUtc()}");
+
+            using var credential = new SMBCredential(credentials.Domain, credentials.Username, credentials.Password, createdTestDirectoryPath, _fixture.SMBCredentialProvider);
+
+            var directoryInfo = _fileSystem.Directory.CreateDirectory(createdTestDirectoryPath);
+
+            Assert.True(_fileSystem.Directory.Exists(createdTestDirectoryPath));
+
+            _fileSystem.Directory.Delete(createdTestDirectoryPath);
+        }
+
+        [Fact]
+        [Trait("Category", "Integration")]
+        public void CanCreateNestedDirectoryInRootDirectory_WithTrailingSeparator()
+        {
+            var credentials = _fixture.ShareCredentials;
+
+            var parentDirectoryPath = _fileSystem.Path.Combine(_fixture.RootPath, $"test_directory_parent-{DateTime.Now.ToFileTimeUtc()}") + $"{(_fixture.PathType == PathType.SmbUri ? '/' : '\\')}";
+            createdTestDirectoryPath = _fileSystem.Path.Combine(parentDirectoryPath, $"test_directory_child-{DateTime.Now.ToFileTimeUtc()}") + $"{(_fixture.PathType == PathType.SmbUri ? '/' : '\\')}";
 
             using var credential = new SMBCredential(credentials.Domain, credentials.Username, credentials.Password, createdTestDirectoryPath, _fixture.SMBCredentialProvider);
 
@@ -91,6 +143,19 @@ namespace SmbAbstraction.Tests.Integration.Directory
 
         [Fact]
         [Trait("Category", "Integration")]
+        public void CanEnumerateFilesRootDirectory_WithTrailingSeparator()
+        {
+            var credentials = _fixture.ShareCredentials;
+
+            using var credential = new SMBCredential(credentials.Domain, credentials.Username, credentials.Password, _fixture.RootPath, _fixture.SMBCredentialProvider);
+
+            var files = _fileSystem.Directory.EnumerateFiles($"{_fixture.RootPath}{(_fixture.PathType == PathType.SmbUri ? '/' : '\\')}", "*").ToList();
+
+            Assert.True(files.Count >= 0); //Include 0 in case directory is empty. If an exception is thrown, the test will fail.
+        }
+
+        [Fact]
+        [Trait("Category", "Integration")]
         public void CanEnumerateFileSystemEntries()
         {
             var credentials = _fixture.ShareCredentials;
@@ -98,6 +163,19 @@ namespace SmbAbstraction.Tests.Integration.Directory
             using var credential = new SMBCredential(credentials.Domain, credentials.Username, credentials.Password, _fixture.RootPath, _fixture.SMBCredentialProvider);
 
             var fileSystemEntries = _fileSystem.Directory.EnumerateFileSystemEntries(_fixture.RootPath).ToList();
+
+            Assert.True(fileSystemEntries.Count >= 0);
+        }
+
+        [Fact]
+        [Trait("Category", "Integration")]
+        public void CanEnumerateFileSystemEntries_WithTrailingSeparator()
+        {
+            var credentials = _fixture.ShareCredentials;
+
+            using var credential = new SMBCredential(credentials.Domain, credentials.Username, credentials.Password, _fixture.RootPath, _fixture.SMBCredentialProvider);
+
+            var fileSystemEntries = _fileSystem.Directory.EnumerateFileSystemEntries($"{_fixture.RootPath}{(_fixture.PathType == PathType.SmbUri ? '/' : '\\')}").ToList();
 
             Assert.True(fileSystemEntries.Count >= 0);
         }
@@ -112,6 +190,18 @@ namespace SmbAbstraction.Tests.Integration.Directory
             using var credential = new SMBCredential(credentials.Domain, credentials.Username, credentials.Password, _fixture.RootPath, _fixture.SMBCredentialProvider);
             
             Assert.True(_fileSystem.Directory.Exists(directory));
+        }
+
+        [Fact]
+        [Trait("Category", "Integration")]
+        public void CheckDirectoryExists_WithTrailingSeparator()
+        {
+            var credentials = _fixture.ShareCredentials;
+            var directory = _fileSystem.Path.Combine(_fixture.RootPath, _fixture.Directories.First());
+
+            using var credential = new SMBCredential(credentials.Domain, credentials.Username, credentials.Password, _fixture.RootPath, _fixture.SMBCredentialProvider);
+
+            Assert.True(_fileSystem.Directory.Exists($"{directory}{(_fixture.PathType == PathType.SmbUri ? '/' : '\\')}"));
         }
     }
 }

--- a/SmbAbstraction.Tests.Integration/Directory/DirectoryTests.cs
+++ b/SmbAbstraction.Tests.Integration/Directory/DirectoryTests.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.IO;
 using System.IO.Abstractions;
 using Xunit.Abstractions;
+using System.Runtime.InteropServices;
 
 namespace SmbAbstraction.Tests.Integration.Directory
 {
@@ -47,7 +48,8 @@ namespace SmbAbstraction.Tests.Integration.Directory
         {
             var credentials = _fixture.ShareCredentials;
 
-            createdTestDirectoryPath = _fileSystem.Path.Combine(_fixture.RootPath, $"test_directory-{DateTime.Now.ToFileTimeUtc()}") + $"{(_fixture.PathType == PathType.SmbUri ? '/' : '\\')}";
+            var trailingSeparator = (_fixture.PathType == PathType.SmbUri || !RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) ? '/' : '\\';
+            createdTestDirectoryPath = _fileSystem.Path.Combine(_fixture.RootPath, $"test_directory-{DateTime.Now.ToFileTimeUtc()}") + trailingSeparator;
 
             using var credential = new SMBCredential(credentials.Domain, credentials.Username, credentials.Password, createdTestDirectoryPath, _fixture.SMBCredentialProvider);
 
@@ -80,7 +82,8 @@ namespace SmbAbstraction.Tests.Integration.Directory
         {
             var credentials = _fixture.ShareCredentials;
 
-            var existingDirectory = _fileSystem.Path.Combine(_fixture.RootPath, _fixture.Directories.First()) + $"{(_fixture.PathType == PathType.SmbUri ? '/' : '\\')}";
+            var trailingSeparator = (_fixture.PathType == PathType.SmbUri || !RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) ? '/' : '\\';
+            var existingDirectory = _fileSystem.Path.Combine(_fixture.RootPath, _fixture.Directories.First()) + trailingSeparator;
 
             using var credential = new SMBCredential(credentials.Domain, credentials.Username, credentials.Password, existingDirectory, _fixture.SMBCredentialProvider);
 
@@ -116,8 +119,9 @@ namespace SmbAbstraction.Tests.Integration.Directory
         {
             var credentials = _fixture.ShareCredentials;
 
-            var parentDirectoryPath = _fileSystem.Path.Combine(_fixture.RootPath, $"test_directory_parent-{DateTime.Now.ToFileTimeUtc()}") + $"{(_fixture.PathType == PathType.SmbUri ? '/' : '\\')}";
-            createdTestDirectoryPath = _fileSystem.Path.Combine(parentDirectoryPath, $"test_directory_child-{DateTime.Now.ToFileTimeUtc()}") + $"{(_fixture.PathType == PathType.SmbUri ? '/' : '\\')}";
+            var trailingSeparator = (_fixture.PathType == PathType.SmbUri || !RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) ? '/' : '\\';
+            var parentDirectoryPath = _fileSystem.Path.Combine(_fixture.RootPath, $"test_directory_parent-{DateTime.Now.ToFileTimeUtc()}") + trailingSeparator;
+            createdTestDirectoryPath = _fileSystem.Path.Combine(parentDirectoryPath, $"test_directory_child-{DateTime.Now.ToFileTimeUtc()}") + trailingSeparator;
 
             using var credential = new SMBCredential(credentials.Domain, credentials.Username, credentials.Password, createdTestDirectoryPath, _fixture.SMBCredentialProvider);
 
@@ -149,7 +153,8 @@ namespace SmbAbstraction.Tests.Integration.Directory
 
             using var credential = new SMBCredential(credentials.Domain, credentials.Username, credentials.Password, _fixture.RootPath, _fixture.SMBCredentialProvider);
 
-            var files = _fileSystem.Directory.EnumerateFiles($"{_fixture.RootPath}{(_fixture.PathType == PathType.SmbUri ? '/' : '\\')}", "*").ToList();
+            var trailingSeparator = (_fixture.PathType == PathType.SmbUri || !RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) ? '/' : '\\';
+            var files = _fileSystem.Directory.EnumerateFiles($"{_fixture.RootPath}{trailingSeparator}", "*").ToList();
 
             Assert.True(files.Count >= 0); //Include 0 in case directory is empty. If an exception is thrown, the test will fail.
         }
@@ -175,7 +180,8 @@ namespace SmbAbstraction.Tests.Integration.Directory
 
             using var credential = new SMBCredential(credentials.Domain, credentials.Username, credentials.Password, _fixture.RootPath, _fixture.SMBCredentialProvider);
 
-            var fileSystemEntries = _fileSystem.Directory.EnumerateFileSystemEntries($"{_fixture.RootPath}{(_fixture.PathType == PathType.SmbUri ? '/' : '\\')}").ToList();
+            var trailingSeparator = (_fixture.PathType == PathType.SmbUri || !RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) ? '/' : '\\';
+            var fileSystemEntries = _fileSystem.Directory.EnumerateFileSystemEntries($"{_fixture.RootPath}{trailingSeparator}").ToList();
 
             Assert.True(fileSystemEntries.Count >= 0);
         }
@@ -201,7 +207,8 @@ namespace SmbAbstraction.Tests.Integration.Directory
 
             using var credential = new SMBCredential(credentials.Domain, credentials.Username, credentials.Password, _fixture.RootPath, _fixture.SMBCredentialProvider);
 
-            Assert.True(_fileSystem.Directory.Exists($"{directory}{(_fixture.PathType == PathType.SmbUri ? '/' : '\\')}"));
+            var trailingSeparator = (_fixture.PathType == PathType.SmbUri || !RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) ? '/' : '\\';
+            Assert.True(_fileSystem.Directory.Exists($"{directory}{trailingSeparator}"));
         }
     }
 }

--- a/SmbAbstraction.Tests.Integration/DirectoryInfo/DirectoryInfoTests.cs
+++ b/SmbAbstraction.Tests.Integration/DirectoryInfo/DirectoryInfoTests.cs
@@ -39,7 +39,9 @@ namespace SmbAbstraction.Tests.Integration.DirectoryInfo
         public void CanCreateNewDirectoryInfo_WithTrailingSeparator()
         {
             var credentials = _fixture.ShareCredentials;
-            var directory = _fileSystem.Path.Combine(_fixture.RootPath, _fixture.Directories.First()) + $"{(_fixture.PathType == PathType.SmbUri ? '/' : '\\')}";
+
+            var trailingSeparator = (_fixture.PathType == PathType.SmbUri || !RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) ? '/' : '\\';
+            var directory = _fileSystem.Path.Combine(_fixture.RootPath, _fixture.Directories.First()) + trailingSeparator;
 
             using var credential = new SMBCredential(credentials.Domain, credentials.Username, credentials.Password, directory, _fixture.SMBCredentialProvider);
 
@@ -73,8 +75,10 @@ namespace SmbAbstraction.Tests.Integration.DirectoryInfo
         public void CheckMoveDirectory_WithTrailingSeparator()
         {
             var credentials = _fixture.ShareCredentials;
-            var directory = _fileSystem.Path.Combine(_fixture.RootPath, _fixture.Directories.First()) + $"{(_fixture.PathType == PathType.SmbUri ? '/' : '\\')}";
-            var newDirectory = _fileSystem.Path.Combine(directory, $"{DateTime.Now.ToFileTimeUtc()}") + $"{(_fixture.PathType == PathType.SmbUri ? '/' : '\\')}";
+
+            var trailingSeparator = (_fixture.PathType == PathType.SmbUri || !RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) ? '/' : '\\';
+            var directory = _fileSystem.Path.Combine(_fixture.RootPath, _fixture.Directories.First()) + trailingSeparator;
+            var newDirectory = _fileSystem.Path.Combine(directory, $"{DateTime.Now.ToFileTimeUtc()}") + trailingSeparator;
 
             using var credential = new SMBCredential(credentials.Domain, credentials.Username, credentials.Password, directory, _fixture.SMBCredentialProvider);
 

--- a/SmbAbstraction.Tests.Integration/DirectoryInfo/DirectoryInfoTests.cs
+++ b/SmbAbstraction.Tests.Integration/DirectoryInfo/DirectoryInfoTests.cs
@@ -36,6 +36,20 @@ namespace SmbAbstraction.Tests.Integration.DirectoryInfo
 
         [Fact]
         [Trait("Category", "Integration")]
+        public void CanCreateNewDirectoryInfo_WithTrailingSeparator()
+        {
+            var credentials = _fixture.ShareCredentials;
+            var directory = _fileSystem.Path.Combine(_fixture.RootPath, _fixture.Directories.First()) + $"{(_fixture.PathType == PathType.SmbUri ? '/' : '\\')}";
+
+            using var credential = new SMBCredential(credentials.Domain, credentials.Username, credentials.Password, directory, _fixture.SMBCredentialProvider);
+
+            var directoryInfo = _fileSystem.DirectoryInfo.FromDirectoryName(directory);
+
+            Assert.NotNull(directoryInfo);
+        }
+
+        [Fact]
+        [Trait("Category", "Integration")]
         public void CheckMoveDirectory()
         {
             var credentials = _fixture.ShareCredentials;
@@ -47,6 +61,26 @@ namespace SmbAbstraction.Tests.Integration.DirectoryInfo
             var createDirectoryPath = _fileSystem.Path.Combine(_fixture.RootPath, $"test-move-local-directory-{DateTime.Now.ToFileTimeUtc()}");
             var directoryInfo = _fileSystem.Directory.CreateDirectory(createDirectoryPath);
             
+            directoryInfo.MoveTo(newDirectory);
+
+            Assert.True(_fileSystem.Directory.Exists(newDirectory));
+
+            _fileSystem.Directory.Delete(newDirectory);
+        }
+
+        [Fact]
+        [Trait("Category", "Integration")]
+        public void CheckMoveDirectory_WithTrailingSeparator()
+        {
+            var credentials = _fixture.ShareCredentials;
+            var directory = _fileSystem.Path.Combine(_fixture.RootPath, _fixture.Directories.First()) + $"{(_fixture.PathType == PathType.SmbUri ? '/' : '\\')}";
+            var newDirectory = _fileSystem.Path.Combine(directory, $"{DateTime.Now.ToFileTimeUtc()}") + $"{(_fixture.PathType == PathType.SmbUri ? '/' : '\\')}";
+
+            using var credential = new SMBCredential(credentials.Domain, credentials.Username, credentials.Password, directory, _fixture.SMBCredentialProvider);
+
+            var createDirectoryPath = _fileSystem.Path.Combine(_fixture.RootPath, $"test-move-local-directory-{DateTime.Now.ToFileTimeUtc()}");
+            var directoryInfo = _fileSystem.Directory.CreateDirectory(createDirectoryPath);
+
             directoryInfo.MoveTo(newDirectory);
 
             Assert.True(_fileSystem.Directory.Exists(newDirectory));

--- a/SmbAbstraction.Tests.Integration/FileInfo/FileInfoTests.cs
+++ b/SmbAbstraction.Tests.Integration/FileInfo/FileInfoTests.cs
@@ -239,5 +239,34 @@ namespace SmbAbstraction.Tests.Integration.FileInfo
 
             _fileSystem.File.Delete(originalFilePath);
         }
+
+        [Fact]
+        [Trait("Category", "Integration")]
+        public void TestCopyWithOverride()
+        {
+            var tempFileName = $"temp-copyto-override-{DateTime.Now.ToFileTimeUtc()}.txt";
+            var credentials = _fixture.ShareCredentials;
+            var testFilePath = _fileSystem.Path.Combine(_fixture.RootPath, _fixture.Files.First());
+            var tempFilePath = _fileSystem.Path.Combine(_fixture.RootPath, tempFileName);
+
+            using var credential = new SMBCredential(credentials.Domain, credentials.Username, credentials.Password, _fixture.RootPath, _fixture.SMBCredentialProvider);
+
+            if (!_fileSystem.File.Exists(tempFilePath))
+            {
+                var stream = _fileSystem.File.Create(tempFilePath);
+                stream.Close();
+            }
+
+            var testFileInfo = _fileSystem.FileInfo.FromFileName(testFilePath);
+
+            testFileInfo.CopyTo(tempFilePath, overwrite: true);
+
+
+            Assert.True(_fileSystem.File.Exists(tempFilePath));
+
+            _fileSystem.File.Delete(tempFilePath);
+        }
+
+
     }
 }

--- a/SmbAbstraction.Tests.Integration/Fixtures/BaseFileSystemFixture.cs
+++ b/SmbAbstraction.Tests.Integration/Fixtures/BaseFileSystemFixture.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -70,6 +71,6 @@ namespace SmbAbstraction.Tests.Integration.Fixtures
             }
         }
 
-        public override PathType PathType => throw new NotImplementedException();
+        public override PathType PathType => PathType.HostFileSystem;
     }
 }

--- a/SmbAbstraction.Tests.Integration/IntegrationTestSettings.cs
+++ b/SmbAbstraction.Tests.Integration/IntegrationTestSettings.cs
@@ -47,7 +47,8 @@ namespace SmbAbstraction.Tests.Integration
     public enum PathType 
     { 
         SmbUri,
-        UncPath
+        UncPath,
+        HostFileSystem
     }
 
     public static class IntegrationTestSettingsExtensions

--- a/SmbAbstraction.Tests/Path/PathExtensionsTests.cs
+++ b/SmbAbstraction.Tests/Path/PathExtensionsTests.cs
@@ -195,7 +195,7 @@ namespace SmbAbstraction.Tests.Path
             foreach (var property in _smbUriTestData.GetType().GetProperties())
             {
                 var path = (string)property.GetValue(_smbUriTestData);
-                var relative = RemoveLeadingSeperator(ReplacePathSeperators(path.Replace(_smbUriTestData.Root, ""), @"\"));
+                var relative = RemoveTrailingSeperator(RemoveLeadingSeperator(ReplacePathSeperators(path.Replace(_smbUriTestData.Root, ""), @"\")));
                 var relativeSharePath = path.RelativeSharePath();
 
                 Assert.Equal(relative, relativeSharePath);
@@ -208,7 +208,7 @@ namespace SmbAbstraction.Tests.Path
             foreach (var property in _uncPathTestData.GetType().GetProperties())
             {
                 var path = (string)property.GetValue(_uncPathTestData);
-                var relative = RemoveLeadingSeperator(ReplacePathSeperators(path.Replace(_uncPathTestData.Root, ""), @"\"));
+                var relative = RemoveTrailingSeperator(RemoveLeadingSeperator(ReplacePathSeperators(path.Replace(_uncPathTestData.Root, ""), @"\")));
                 var relativeSharePath = path.RelativeSharePath();
 
                 Assert.Equal(relative, relativeSharePath);
@@ -236,6 +236,21 @@ namespace SmbAbstraction.Tests.Path
                 if (input.StartsWith(pathSeperator))
                 {
                     input = input.Remove(0, 1);
+                }
+            }
+
+            return input;
+        }
+
+        private string RemoveTrailingSeperator(string input)
+        {
+            string[] pathSeperators = { @"\", @"/" };
+
+            foreach (var pathSeperator in pathSeperators)
+            {
+                if (input.EndsWith(pathSeperator))
+                {
+                    input = input.Remove(input.LastIndexOf(pathSeperator), 1);
                 }
             }
 

--- a/SmbAbstraction.Tests/Path/PathTestData.cs
+++ b/SmbAbstraction.Tests/Path/PathTestData.cs
@@ -14,10 +14,12 @@
     {
         public string Root { get { return "smb://host/share"; } }
         public string DirectoryAtRoot { get { return "smb://host/share/dir"; } }
+        public string DirectoryAtRootWithTrailingSlash { get { return "smb://host/share/dir"; } }
         public string SpaceInDirectoryAtRoot { get { return "smb://host/share/dir dir/file.txt"; } }
         public string FileAtRoot { get { return "smb://host/share/file.txt"; } }
         public string SpaceInFileAtRoot { get { return "smb://host/share/text file.txt"; } }
         public string NestedDirectoryAtRoot {  get { return "smb://host/share/dir/nested_dir"; } }
+        public string NestedDirectoryAtRootWithTrailingSlash { get { return "smb://host/share/dir/nested_dir/"; } }
         public string FileInNestedDirectoryAtRoot { get { return "smb://host/share/dir/nested_dir/file.txt"; } }
         public string SpaceInFileInNestedDirectoryAtRoot { get { return "smb://host/share/dir/nested_dir/text file.txt"; } }
         public string SpaceInFileAndInNestedDirectoryAtRoot { get { return "smb://host/share/dir/nested dir/text file.txt"; } }
@@ -28,11 +30,14 @@
     {
         public string Root { get { return $@"\\host\share"; } }
         public string DirectoryAtRoot { get { return $@"\\host\share\dir"; } }
+        public string DirectoryAtRootWithTrailingSlash { get { return $@"\\host\share\dir\"; } }
         public string SpaceInDirectoryAtRoot { get { return @"\\host\share\dir dir\file.txt"; } }
         public string FileAtRoot { get { return $@"\\host\share\file.txt"; } }
         public string SpaceInFileAtRoot { get { return @"\\host\share\text file.txt"; } }
         public string NestedDirectoryAtRoot { get { return $@"\\host\share\dir\nested_dir"; } }
+        public string NestedDirectoryAtRootWithTrailingSlash { get { return $@"\\host\share\dir\nested_dir\"; } }
         public string SpaceInNestedDirectoryAtRoot { get { return $@"\\host\share\dir\nested dir"; } }
+        public string SpaceInNestedDirectoryAtRootWithTrailingSlash { get { return $@"\\host\share\dir\nested dir\"; } }
         public string FileInNestedDirectoryAtRoot { get { return $@"\\host\share\dir\nested_dir\file.text"; } }
         public string SpaceInFileInNestedDirectoryAtRoot { get { return $@"\\host\share\dir\nested_dir\text file.text"; } }
         public string SpaceInFileAndInNestedDirectoryAtRoot { get { return $@"\\host\share\dir\nested dir\text file.text"; } }

--- a/SmbAbstraction/Extensions/PathExtensions.cs
+++ b/SmbAbstraction/Extensions/PathExtensions.cs
@@ -141,7 +141,7 @@ namespace SmbAbstraction
 
         public static string RelativeSharePath(this string path)
         {
-            var relativePath = path.RemoveShareNameFromPath().RemoveLeadingSeperators().Replace("/", @"\");
+            var relativePath = path.RemoveShareNameFromPath().RemoveLeadingAndTrailingSeperators().Replace("/", @"\");
 
             return relativePath;
         }
@@ -162,7 +162,7 @@ namespace SmbAbstraction
 
         public static string RemoveLeadingAndTrailingSeperators(this string input)
         {
-            return input.RemoveLeadingSeperators().RemoveLeadingSeperators();
+            return input.RemoveLeadingSeperators().RemoveTrailingSeperators();
         }
 
         public static string RemoveLeadingSeperators(this string input)

--- a/SmbAbstraction/SmbAbstraction.csproj
+++ b/SmbAbstraction/SmbAbstraction.csproj
@@ -12,7 +12,7 @@
     <PackageId>SmbAbstraction</PackageId>
     <RepositoryUrl>https://github.com/jordanlytle/SmbAbstraction</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <PackageVersion>1.1.10-alpha</PackageVersion>
+    <PackageVersion>1.1.10-alpha-01</PackageVersion>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -20,7 +20,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <Version>1.1.10-alpha</Version>
+    <Version>1.1.10-alpha-01</Version>
   </PropertyGroup>
   
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
## [1.1.10-alpha-01] 2020-05-15

### Changed
- Close any potential `fileStore` and `handles` in `SMBDirectory.Exists` and `SMBFile.Exists` when an exception is caught before returning false
- Added `SMBDirectory` and `SMBDirectoryInfo` tests that check if operations succeed with trailing separators

### Fixed
- `PathExtensions.RemoveLeadingAndTrailingSeparators()` was calling `RemoveLeadingSeparators` twice and not calling `RemoveTrailingSeparators`


## [1.1.10-alpha] 2020-05-12

### Changed
- Update SMBLibraryLite to 1.4.3-alpha
	- Temporaily Fixes "Not enough credits" exception when reading large files


