### PR TITLE
Bump version to 1.1.10-beta and update SMBLibraryLite to 1.4.3-beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project tries to adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.10-beta] 2020-05-15
+
+### Changed
+- Update SMBLibraryLite to 1.4.3-beta
+	- Prevents STATUS_PENDING from being returned from SMB2Client.WaitOnCommand().
+
 ## [1.1.10-alpha-01] 2020-05-15
 
 ### Changed

--- a/SmbAbstraction/SmbAbstraction.csproj
+++ b/SmbAbstraction/SmbAbstraction.csproj
@@ -12,7 +12,7 @@
     <PackageId>SmbAbstraction</PackageId>
     <RepositoryUrl>https://github.com/jordanlytle/SmbAbstraction</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <PackageVersion>1.1.10-alpha-01</PackageVersion>
+    <PackageVersion>1.1.10-beta</PackageVersion>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -20,7 +20,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <Version>1.1.10-alpha-01</Version>
+    <Version>1.1.10-beta</Version>
   </PropertyGroup>
   
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -37,7 +37,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="SMBLibraryLite" Version="1.4.3-alpha" />
+    <PackageReference Include="SMBLibraryLite" Version="1.4.3-beta" />
   </ItemGroup>
   <ItemGroup>
     <Compile Remove="SMBPath.cs" />


### PR DESCRIPTION
## [1.1.10-beta] 2020-05-15

### Changed
- Update SMBLibraryLite to 1.4.3-beta
	- Prevents STATUS_PENDING from being returned from SMB2Client.WaitOnCommand().