### PR TITLE
Release unusable SMBConnection

### DIFF
--- a/SmbAbstraction/Drive/SMBDriveInfo.cs
+++ b/SmbAbstraction/Drive/SMBDriveInfo.cs
@@ -13,7 +13,7 @@ namespace SmbAbstraction
         public SMBDriveInfo(string path, IFileSystem fileSystem, SMBFileSystemInformation smbFileSystemInformation, ISMBCredential credential)
         {
             FileSystem = fileSystem;
-            DriveFormat = smbFileSystemInformation.AttributeInformation.FileSystemName;
+            DriveFormat = smbFileSystemInformation.AttributeInformation?.FileSystemName;
             Name = path.ShareName();
             RootDirectory = _dirInfoFactory.FromDirectoryName(path, credential);
             var actualAvailableAllocationUnits = smbFileSystemInformation.SizeInformation.ActualAvailableAllocationUnits;

--- a/SmbAbstraction/File/SMBFile.cs
+++ b/SmbAbstraction/File/SMBFile.cs
@@ -607,9 +607,10 @@ namespace SmbAbstraction
                 throw new SMBException($"Failed to Open {path}", new InvalidCredentialException($"Unable to find credential in SMBCredentialProvider for path: {path}"));
             }
 
+            SMBConnection connection = null;
             try
             {
-                var connection = SMBConnection.CreateSMBConnection(_smbClientFactory, ipAddress, transport, credential, _maxBufferSize);
+                connection = SMBConnection.CreateSMBConnection(_smbClientFactory, ipAddress, transport, credential, _maxBufferSize);
 
                 var shareName = path.ShareName();
                 var relativePath = path.RelativeSharePath();
@@ -677,6 +678,8 @@ namespace SmbAbstraction
             }
             catch (Exception ex)
             {
+                // Dispose connection if fail to open stream
+                connection?.Dispose();
                 throw new SMBException($"Failed to Open {path}", ex);
             }
         }


### PR DESCRIPTION
When SMBConnection is not connected, we need to dispose it in order to create a new one.