### PR TITLE
Fix path hostname resolution in DriveInfoFactory

### DIFF
--- a/SmbAbstraction/Drive/SMBDriveInfoFactory.cs
+++ b/SmbAbstraction/Drive/SMBDriveInfoFactory.cs
@@ -70,7 +70,7 @@ namespace SmbAbstraction
                 }
             }
 
-            var path = credential.Path;
+            var path = credential.Path.SharePath();
             if (!path.TryResolveHostnameFromPath(out var ipAddress))
             {
                 throw new SMBException($"Failed FromDriveName for {shareName}", new ArgumentException($"Unable to resolve \"{path.Hostname()}\""));


### PR DESCRIPTION
When video is playing, we created credentials for each video path. When requesting drive info at the same time, it may resolve to the credential to the video file instead of the drive. The path point to file failed to get drive information and caused exception. Fix to point to the SharePath as drive path.