### PR TITLE
Create non-shared SMBConnection for SMBStream

### DIFF
--- a/SmbAbstraction/Client/SMBConnection.cs
+++ b/SmbAbstraction/Client/SMBConnection.cs
@@ -47,6 +47,21 @@ namespace SmbAbstraction
             status.HandleStatus();
         }
 
+        public static SMBConnection CreateSMBConnectionForStream(ISMBClientFactory smbClientFactory,
+            IPAddress address, SMBTransportType transport, ISMBCredential credential, uint maxBufferSize)
+        {
+            if (credential == null)
+            {
+                throw new ArgumentNullException(nameof(credential));
+            }
+
+            // Create new connection
+            var instance = new SMBConnection(smbClientFactory, address, transport, credential, -1,
+                maxBufferSize);
+            instance.Connect();
+            return instance;
+        }
+
         public static SMBConnection CreateSMBConnection(ISMBClientFactory smbClientFactory,
             IPAddress address, SMBTransportType transport, ISMBCredential credential, uint maxBufferSize)
         {
@@ -114,11 +129,15 @@ namespace SmbAbstraction
                     }
                     finally
                     {
-                        instances[_threadId].Remove(_address);
-                        if (instances[_threadId].Count == 0)
+                        if (_threadId != -1)
                         {
-                            instances.Remove(_threadId);
+                            instances[_threadId].Remove(_address);
+                            if (instances[_threadId].Count == 0)
+                            {
+                                instances.Remove(_threadId);
+                            }
                         }
+
                         _isDesposed = true;
                     }
                 }

--- a/SmbAbstraction/File/SMBFile.cs
+++ b/SmbAbstraction/File/SMBFile.cs
@@ -610,7 +610,7 @@ namespace SmbAbstraction
             SMBConnection connection = null;
             try
             {
-                connection = SMBConnection.CreateSMBConnection(_smbClientFactory, ipAddress, transport, credential, _maxBufferSize);
+                connection = SMBConnection.CreateSMBConnectionForStream(_smbClientFactory, ipAddress, transport, credential, _maxBufferSize);
 
                 var shareName = path.ShareName();
                 var relativePath = path.RelativeSharePath();


### PR DESCRIPTION
For stream create SMBConnection that is not shared by others. So it won't cause conflict during async read and write.