### PR TITLE
Update SMBDirectory.Exists to call SMBFile.Exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,9 +128,3 @@ public void UseStoredCredentialsForFileOp()
     }
 }
 ```
-
-
-# Notes
-
-Currently the maxBufferSize needs to be set to the default, which is 65536. The server *should* be using
-the buffer size that it sends back to the client, but doesn't seem to be honoring that. 

--- a/SmbAbstraction.Tests.Integration/Directory/DirectoryTests.cs
+++ b/SmbAbstraction.Tests.Integration/Directory/DirectoryTests.cs
@@ -200,6 +200,18 @@ namespace SmbAbstraction.Tests.Integration.Directory
 
         [Fact]
         [Trait("Category", "Integration")]
+        public void CheckDirectoryDoesNotExistWhenPathIsFile()
+        {
+            var credentials = _fixture.ShareCredentials;
+            var directory = _fileSystem.Path.Combine(_fixture.RootPath, _fixture.Files.First());
+
+            using var credential = new SMBCredential(credentials.Domain, credentials.Username, credentials.Password, _fixture.RootPath, _fixture.SMBCredentialProvider);
+
+            Assert.False(_fileSystem.Directory.Exists(directory));
+        }
+
+        [Fact]
+        [Trait("Category", "Integration")]
         public void CheckDirectoryExists_WithTrailingSeparator()
         {
             var credentials = _fixture.ShareCredentials;

--- a/SmbAbstraction.Tests.Integration/File/FileTests.cs
+++ b/SmbAbstraction.Tests.Integration/File/FileTests.cs
@@ -74,6 +74,18 @@ namespace SmbAbstraction.Tests.Integration.File
 
         [Fact]
         [Trait("Category", "Integration")]
+        public void TestExistsForDirectory()
+        {
+            var credentials = _fixture.ShareCredentials;
+            var filePath = _fileSystem.Path.Combine(_fixture.RootPath, _fixture.Directories.First());
+
+            using var credential = new SMBCredential(credentials.Domain, credentials.Username, credentials.Password, _fixture.RootPath, _fixture.SMBCredentialProvider);
+
+            Assert.False(_fileSystem.File.Exists(filePath));
+        }
+
+        [Fact]
+        [Trait("Category", "Integration")]
         public void TestMove()
         {
             var tempFileName = $"temp-{DateTime.Now.ToFileTimeUtc()}.txt";

--- a/SmbAbstraction/Directory/SMBDirectory.cs
+++ b/SmbAbstraction/Directory/SMBDirectory.cs
@@ -678,6 +678,13 @@ namespace SmbAbstraction
                 return base.Exists(path);
             }
 
+            // For some reason Directory.Exists is returning true if a file exists at that path. 
+            // File.Exists works properly so as long as we check it here we are fine.
+            if(_fileSystem.File.Exists(path))
+            {
+                return false;
+            }
+
             ISMBFileStore fileStore = null;
             object handle = null;
 


### PR DESCRIPTION
This fixes a bug where SMBDirectory.Exists returns true for both files
and Directories.